### PR TITLE
#8 Ignore query and continuation operator for the route

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -19,7 +19,8 @@ exports.setRoute = function(app, method, url, action){
         };
     };
 
-    var translatedUrl = url.replace(/\{/g, ':').replace(/\}/g, '');
+    // Ignore query and continuation operator for the route
+    var translatedUrl = url.replace(/\{\?.*\}/g, '').replace(/\{\&.*\}/g, '').replace(/\{/g, ':').replace(/\}/g, '');
 
     action.examples.forEach(function(example){
 


### PR DESCRIPTION
Based on https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#uri-template-variable, it's necessary to ignore these operators to not break the express route.

With this change is possible to have:

```
/users{?page,limit,order}
/users?page=1{&limit,order}
/users/{id}{?page,limit,order}
```

Fix #8 