### PR TITLE
Add option to add methods to Access-Control-Allow-Methods header

### DIFF
--- a/lib/arguments.js
+++ b/lib/arguments.js
@@ -32,6 +32,9 @@ var optimistOptions = {
     },
     delay: {
         description: 'Add a delay to the response (in milliseconds)'
+    },
+    method: {
+        description: 'Add method to Access-Control-Allow-Methods response header'
     }
 };
 

--- a/lib/drakov.js
+++ b/lib/drakov.js
@@ -29,6 +29,7 @@ exports.run = function(argv, cb) {
     app.use(responseUtils.drakovHeaders);
     app.use(responseUtils.corsHeaders(argv.disableCORS));
     app.use(responseUtils.delayedResponse(argv.delay));
+    app.use(responseUtils.allowMethods(argv.method));
 
     if (argv.staticPaths) {
         static.setupRoutes(app, argv.staticPaths, argv.pathDelimiter);

--- a/lib/drakov.js
+++ b/lib/drakov.js
@@ -6,6 +6,7 @@ require('colors');
 
 var logger = require('./logger');
 var requestUtils = require('./request');
+var responseUtils = require('./response');
 var file = require('./file');
 var static = require('./static');
 var setup = require('./setup');
@@ -19,13 +20,15 @@ exports.run = function(argv, cb) {
     console.log('\n', '   Bootstrapping   '.bold.inverse, '\n');
 
     var app = express();
-    app.use(requestUtils.headers);
-    if (!argv.disableCORS) {
-        app.use(requestUtils.corsHeaders);
-    }
+
+    // REQUEST MIDDLEWARE
     app.use(requestUtils.logger);
     app.use(requestUtils.getBody);
-    app.use(requestUtils.delayedResponse(argv.delay));
+
+    // RESPONSE MIDDLEWARE
+    app.use(responseUtils.drakovHeaders);
+    app.use(responseUtils.corsHeaders(argv.disableCORS));
+    app.use(responseUtils.delayedResponse(argv.delay));
 
     if (argv.staticPaths) {
         static.setupRoutes(app, argv.staticPaths, argv.pathDelimiter);

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,27 +10,7 @@ exports.getBody = function(req, res, next) {
     req.on('end', next);
 };
 
-exports.delayedResponse = function(delay){
-    return function(req, req, next){
-        if(!delay){
-            return next();
-        }
-        logger.log('[DELAY]'.yellow, delay+'ms');
-        setTimeout(next, delay);
-    };
-};
-
 exports.logger = function(req, res, next) {
     logger.log('[LOG]'.white, req.method.green, req.url.yellow);
-    next();
-};
-
-exports.headers = function(req, res, next) {
-    res.set('X-Powered-By', 'Drakov API Server');
-    next();
-};
-
-exports.corsHeaders = function(req, res, next) {
-    res.set('Access-Control-Allow-Origin', '*');
     next();
 };

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,0 +1,26 @@
+require('colors');
+var logger = require('./logger');
+
+exports.delayedResponse = function(delay){
+    return function(req, req, next){
+        if(!delay){
+            return next();
+        }
+        logger.log('[DELAY]'.yellow, delay+'ms');
+        setTimeout(next, delay);
+    };
+};
+
+exports.drakovHeaders = function(req, res, next) {
+    res.set('X-Powered-By', 'Drakov API Server');
+    next();
+};
+
+exports.corsHeaders = function(disableCORS) {
+    return function(req, res, next) {
+        if (!disableCORS) {
+            res.set('Access-Control-Allow-Origin', '*');
+        }
+        next();
+    };
+};

--- a/lib/response.js
+++ b/lib/response.js
@@ -24,3 +24,13 @@ exports.corsHeaders = function(disableCORS) {
         next();
     };
 };
+
+exports.allowMethods = function(allowMethods) {
+    return function(req, res, next) {
+        if (allowMethods) {
+            var methods = Array.isArray(allowMethods) ? allowMethods.join(',') : allowMethods;
+            res.set('Access-Control-Allow-Methods', methods);
+        }
+        next();
+    };
+};

--- a/test/api/headers-allow-methods-test.js
+++ b/test/api/headers-allow-methods-test.js
@@ -1,0 +1,26 @@
+var helper = require('../lib');
+var request = helper.getRequest();
+
+describe('HEADERS', function(){
+
+    before(function (done) {
+        helper.drakov.run({sourceFiles: 'test/example/md/headers.md', method: ['DELETE', 'OPTIONS']}, done);
+    });
+
+    after(function (done) {
+        helper.drakov.stop(done);
+    });
+
+    describe('/headers', function(){
+
+        describe('DELETE', function(){
+            it('should respond with HTTP 200 and Access-Control-Allow-Methods', function(done){
+                request.delete('/headers')
+                .expect(200)
+                .expect('Access-Control-Allow-Methods', 'DELETE,OPTIONS')
+                .end(helper.endCb(done));
+            });
+        });
+    });
+
+});

--- a/test/example/md/headers.md
+++ b/test/example/md/headers.md
@@ -24,6 +24,12 @@ Check Authorization header
 
 + Response 401
 
+### Delete a dummy object [DELETE]
+Respond to deletion of object
+
++ Request
+
++ Response 200
 
 ## Things [/things]
 


### PR DESCRIPTION
Tidy up the request/response middleware modules.
Add support for a `Access-Control-Allow-Methods` header in the response.