### PR TITLE
 Added functionality to support x-www--form-urlencoded content type.

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -1,5 +1,5 @@
 var lodash = require('lodash');
-var url = require('./url-parser');
+var urlParser = require('./url-parser');
 
 var mediaTypeRe = /^\s*([^;]+)/i;
 
@@ -34,9 +34,9 @@ function isBodyEqual( httpReq, specReq, contentType ) {
         return true;
     }
 
-    if (contentType.indexOf('application/x-www-form-urlencoded') > -1) {
+    if (/application\/x-www-form-urlencoded/i.test(contentType)) {
         var jsonEncodedSpecBody = JSON.parse(specReq.body);
-        return url.jsonToFormEncodedString(jsonEncodedSpecBody) === httpReq.body;
+        return urlParser.jsonToFormEncodedString(jsonEncodedSpecBody) === httpReq.body;
     }
 
     if (/json/i.test(contentType)){

--- a/lib/content.js
+++ b/lib/content.js
@@ -1,4 +1,5 @@
 var lodash = require('lodash');
+var url = require('./url-parser');
 
 var mediaTypeRe = /^\s*([^;]+)/i;
 
@@ -31,6 +32,11 @@ function isBodyEqual( httpReq, specReq, contentType ) {
 
     if (httpReq.body === specReq.body){
         return true;
+    }
+
+    if (contentType.indexOf('application/x-www-form-urlencoded') > -1) {
+        var jsonEncodedSpecBody = JSON.parse(specReq.body);
+        return url.jsonToFormEncodedString(jsonEncodedSpecBody) === httpReq.body;
     }
 
     if (/json/i.test(contentType)){

--- a/lib/url-parser.js
+++ b/lib/url-parser.js
@@ -29,3 +29,12 @@ exports.parse = function (url) {
         url: processPathname(urlArr[0])
     };
 };
+
+exports.jsonToFormEncodedString = function(objectData) {
+    //To transform data as form data so that backend can understand as Form Data rather Payload
+    var arrayStr = [];
+    for(var key in objectData) {
+        arrayStr.push(encodeURIComponent(key) + '=' + encodeURIComponent(objectData[key]));
+    }
+    return arrayStr.join('&');
+};

--- a/test/api/multiple-examples-api-test.js
+++ b/test/api/multiple-examples-api-test.js
@@ -51,6 +51,16 @@ describe('/api/multiple', function(){
                 .expect({'second': 'example','status': 'ok'})
                 .end(helper.endCb(done));
         });
+
+        it('should respond with json object from the third body example', function(done){
+            request.post('/api/multiple')
+                .set('Content-type', 'application/x-www-form-urlencoded')
+                .send({third: 'example'})
+                .expect(200)
+                .expect('Content-type', 'application/json; charset=utf-8')
+                .expect({third: 'example',status: 'ok'})
+                .end(helper.endCb(done));
+        });
     });
 
 });

--- a/test/example/md/multiple-examples-api.md
+++ b/test/example/md/multiple-examples-api.md
@@ -76,4 +76,26 @@ Second POST example with body
             "status": "ok"
         }
 
+### Post to the third example [POST]
 
++ Request
+Second POST example with body
+
+    + Headers
+
+        content-type: application/x-www-form-urlencoded
+
+    + Body
+
+        {
+            "third": "example"
+        }
+
++ Response 200 (application/json;charset=UTF-8)
+
+    + Body
+
+        {
+            "third": "example",
+            "status": "ok"
+        }

--- a/test/unit/url-parser-test.js
+++ b/test/unit/url-parser-test.js
@@ -70,4 +70,17 @@ describe('URL Parser', function() {
         });
     });
 
+    describe('JSON to Form Encoded String', function() {
+        it('should encode JSON Object as a form data for POST request', function() {
+
+            var formObj = {
+                test1: 'foo',
+                test2: 'bar'
+            };
+
+            var expectedData = urlParser.jsonToFormEncodedString(formObj);
+            assert.equal(expectedData, 'test1=foo&test2=bar');
+        });
+    });
+
 });


### PR DESCRIPTION
In the current version of drakov if we send urlencoded form data, there were two problems with it.

- The request body for form-encoded post urls was not readable

   In the md file we have to send data like this:-

   + Body 
      `example=23&foo=bar`

      which was not readable. So after our changes in the md file, the request body can be written like a normal   JSON:-

    + Body

    `{
       example: 23,
       foor: bar
    }`

- Issue with the request BODY when it is not in JSON format  
 In file `content.js` there was check where we are equating the body of spec and http when the content type was not json, also  `/n`  was appended to the spec body automatically.

    
