### PR TITLE
Added support for Multipart blueprint specifications

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -31,6 +31,14 @@ function isJsonBody(contentType) {
     return contentType ? /json/i.test(contentType) : false;
 }
 
+function isMultipartContentType(contentType) {
+    if(/multipart\/form-data/i.test(contentType)) {
+        return true;
+    }
+
+    return false;
+}
+
 function getBodyContent(req, contentType){
     var body = null;
     if (req && req.body) {
@@ -67,6 +75,10 @@ function isBodyEqual( httpReq, specReq, contentType ) {
         return true;
     }
 
+    if(isMultipartContentType(contentType)) {
+        return true;
+    }
+
     if (/application\/x-www-form-urlencoded/i.test(contentType)) {
         var jsonEncodedSpecBody = JSON.parse(specBody);
         return urlParser.jsonToFormEncodedString(jsonEncodedSpecBody) === reqBody;
@@ -99,10 +111,22 @@ function hasHeaders( httpReq, specReq ){
     return specReq.headers.every(containsHeader);
 }
 
+function areContentTypesSame(httpMediaType, specMediaType) {
+    if(httpMediaType === specMediaType) {
+        return true;
+    }
+
+    if(isMultipartContentType(httpMediaType) && isMultipartContentType(specMediaType)) {
+        return true;
+    }
+
+    return false;
+}
+
 exports.matches = function( httpReq, specReq ) {
     var httpMediaType = getMediaTypeFromHttpReq( httpReq );
     var specMediaType = getMediaTypeFromSpecReq( specReq );
-    if ( httpMediaType === specMediaType ) {
+    if ( areContentTypesSame(httpMediaType, specMediaType) ) {
         if ( !hasHeaders( httpReq, specReq ) ){
             return false;
         }

--- a/test/api/multipart-test.js
+++ b/test/api/multipart-test.js
@@ -1,0 +1,44 @@
+var helper = require('../lib');
+var request = helper.getRequest();
+
+describe('Multipart Requests', function() {
+    before(function (done) {
+        helper.drakov.run({sourceFiles: 'test/example/md/multipart.md'}, done);
+    });
+
+    after(function (done) {
+        helper.drakov.stop(done);
+    });
+
+    describe('/api/multipart', function() {
+        it('should respond with success response for Same Multipart Content Type', function(done) {
+            request.post('/api/multipart')
+            .set('Content-type', 'multipart/form-data; boundary=---BOUNDARY')
+            .send()
+            .expect(200)
+            .expect('Content-type', 'application/json;charset=UTF-8')
+            .expect({success: true})
+            .end(helper.endCb(done));
+        });
+
+        it('should respond with success response for Same Multipart Content Type with different boundary', function(done) {
+            request.post('/api/multipart')
+            .set('Content-type', 'multipart/form-data; boundary=---WebKitFormBoundaryjy0tIlk46ESOni0H')
+            .send()
+            .expect(200)
+            .expect('Content-type', 'application/json;charset=UTF-8')
+            .expect({success: true})
+            .end(helper.endCb(done));
+        });
+
+        it('should respond with error when request does not have Content Type as multipart', function(done) {
+            request.post('/api/multipart')
+            .set('Content-type', 'application/json')
+            .send()
+            .expect(404)
+            .expect('Content-type', 'text/html; charset=utf-8')
+            .end(helper.endCb(done));
+        });
+    });
+
+});

--- a/test/example/md/multipart.md
+++ b/test/example/md/multipart.md
@@ -1,0 +1,27 @@
+FORMAT: 1A
+
+# Accept Multipart
+Accept Multipart data and return response
+
+## Things [/api/multipart]
+
+### Accept Multipart data [POST]
+
++ Request (multipart/form-data; boundary=---BOUNDARY)
+
+        -----BOUNDARY
+        /9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+        HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+        MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIA
+        AhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEB
+        AAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AL+AD//Z
+        -----BOUNDARY
+
++ Response 200 (application/json;charset=UTF-8)
+
+    + Body
+
+            {
+              "success": true
+            }
+          


### PR DESCRIPTION
For request containing multipart form data, browsers provide dynamic form boundary values (like `WebKitFormBoundaryjy0tIlk46ESOni0H`) which in turn change the content type (to something like `multipart/form-data; boundary=---WebKitFormBoundaryjy0tIlk46ESOni0H`)

Moreover, request body also can be different because of form boundary. 

Sample Request body:

        ------WebKitFormBoundaryjy0tIlk46ESOni0H
        Content-Disposition: form-data; name="documentImportId"

        undefined
        ------WebKitFormBoundaryjy0tIlk46ESOni0H
        Content-Disposition: form-data; name="qquuid"

        e3a2d2ed-0554-42c2-9629-3fad804547d8
        ------WebKitFormBoundaryjy0tIlk46ESOni0H
        Content-Disposition: form-data; name="qqfilename"

        tmprp8v07
        ------WebKitFormBoundaryjy0tIlk46ESOni0H
        Content-Disposition: form-data; name="qqtotalfilesize"

        -1
        ------WebKitFormBoundaryjy0tIlk46ESOni0H
        Content-Disposition: form-data; name="qqfile"; filename="tmprp8v07"
        Content-Type: application/octet-stream

        ------WebKitFormBoundaryjy0tIlk46ESOni0H--

This patch supports this behavior. If content types provided in the request and in spec are both "multipart/form-data" then request body check is not performed and the relevant response provided in the spec is served.

Todo:
 + Check how to serve different responses based on the request body if content type is `multipart/form-data` in both cases