### PR TITLE
support preferred status code as response

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Due to protagonist parsing being async, we need to setup the middleware with an 
 
 **Q:** If I have multiple requests/responses on the same API endpoint, which response will I get?
 
-**A:** Drakov will respond first with any responses that have a JSON schema with the first response matching the request body for that API endpoint.
+**A:** Drakov will respond first with any responses that have a JSON schema with the first response matching the request body for that API endpoint. You can request a specific response by adding a `Prefer` header to the request in the form `Prefer:status=XXX` where `XXX` is the status code of the desired response.
 
 
 **Q:** If I have multiple responses on a single request, which response will I get?

--- a/lib/content.js
+++ b/lib/content.js
@@ -21,19 +21,29 @@ function getMediaTypeFromSpecReq( specReq ) {
 }
 
 function getMediaTypeFromHttpReq( httpReq ) {
-    if( 'content-type' in httpReq.headers ) {
-        return getMediaType( httpReq.headers['content-type'] );
+    var contentTypeHeader = getHeaderFromHttpReq( httpReq, 'content-type' );
+    if( contentTypeHeader ) {
+        return getMediaType( contentTypeHeader );
     }
     return null;
 }
 
-function getPreferredStatusFromHttpReq( httpReq ) {
+function getPreferHeaderFromHttpReq( httpReq, preference ) {
+    var preferHeader = getHeaderFromHttpReq( httpReq, 'prefer' );
+    var preferenceRegExp = new RegExp(preference + '=(.*)');
     var matchedStatus;
-    if ( 'prefer' in httpReq.headers ) {
-        matchedStatus = httpReq.headers.prefer.match(/status=(\d+)/i);
+    if ( preferHeader ) {
+        matchedStatus = preferHeader.match(preferenceRegExp);
         if (matchedStatus) {
             return matchedStatus[1];
         }
+    }
+    return null;
+}
+
+function getHeaderFromHttpReq( httpReq, header ) {
+    if ( header in httpReq.headers ) {
+        return httpReq.headers[header];
     }
     return null;
 }
@@ -142,7 +152,7 @@ exports.matches = function( httpReq, spec ) {
     var specReq = spec.request;
     var httpMediaType = getMediaTypeFromHttpReq( httpReq );
     var specMediaType = getMediaTypeFromSpecReq( specReq );
-    var preferredStatus = getPreferredStatusFromHttpReq( httpReq );
+    var preferredStatus = getPreferHeaderFromHttpReq( httpReq, 'status' );
 
     if ( !preferredStatus || isPreferredStatus(spec, preferredStatus) ) {
         if (areContentTypesSame(httpMediaType, specMediaType)) {

--- a/lib/content.js
+++ b/lib/content.js
@@ -30,7 +30,7 @@ function getMediaTypeFromHttpReq( httpReq ) {
 
 function getPreferHeaderFromHttpReq( httpReq, preference ) {
     var preferHeader = getHeaderFromHttpReq( httpReq, 'prefer' );
-    var preferenceRegExp = new RegExp(preference + '=(.*)');
+    var preferenceRegExp = new RegExp(preference + '=(.*)', 'i');
     var matchedStatus;
     if ( preferHeader ) {
         matchedStatus = preferHeader.match(preferenceRegExp);

--- a/lib/content.js
+++ b/lib/content.js
@@ -27,6 +27,17 @@ function getMediaTypeFromHttpReq( httpReq ) {
     return null;
 }
 
+function getPreferredStatusFromHttpReq( httpReq ) {
+    var matchedStatus;
+    if ( 'prefer' in httpReq.headers ) {
+        matchedStatus = httpReq.headers.prefer.match(/status=(\d+)/i);
+        if (matchedStatus) {
+            return matchedStatus[1];
+        }
+    }
+    return null;
+}
+
 function isJsonBody(contentType) {
     return contentType ? /json/i.test(contentType) : false;
 }
@@ -123,16 +134,28 @@ function areContentTypesSame(httpMediaType, specMediaType) {
     return false;
 }
 
-exports.matches = function( httpReq, specReq ) {
+function isPreferredStatus(spec, preferredStatus) {
+    return spec.response.name === preferredStatus;
+}
+
+exports.matches = function( httpReq, spec ) {
+    var specReq = spec.request;
     var httpMediaType = getMediaTypeFromHttpReq( httpReq );
     var specMediaType = getMediaTypeFromSpecReq( specReq );
-    if ( areContentTypesSame(httpMediaType, specMediaType) ) {
-        if ( !hasHeaders( httpReq, specReq ) ){
-            return false;
-        }
+    var preferredStatus = getPreferredStatusFromHttpReq( httpReq );
 
-        if ( isBodyEqual( httpReq, specReq, httpMediaType ) ) {
-            return true;
+    if ( !preferredStatus || isPreferredStatus(spec, preferredStatus) ) {
+        if (areContentTypesSame(httpMediaType, specMediaType)) {
+            if (!hasHeaders(httpReq, specReq)) {
+                return false;
+            }
+
+            if (isBodyEqual(httpReq, specReq, httpMediaType)) {
+                return true;
+            } else {
+                return false;
+            }
+
         } else {
             return false;
         }

--- a/lib/route.js
+++ b/lib/route.js
@@ -20,7 +20,7 @@ exports.getRouteHandlers = function (method, parsedUrl, action) {
             };
 
             var matchRequests= function (specPair){
-                if (content.matches(req, specPair.request)) {
+                if (content.matches(req, specPair)) {
                     logger.log('[DRAKOV]'.red, action.method.green, parsedUrl.uriTemplate.yellow, (specPair.request && specPair.request.description ? specPair.request.description : action.name).blue);
 
                     specPair.response.headers.forEach(function (header) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drakov",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Mock server that implements the API Blueprint specification",
   "main": "./lib/drakov.js",
   "bin": {

--- a/test/api/multiple-examples-api-test.js
+++ b/test/api/multiple-examples-api-test.js
@@ -29,6 +29,15 @@ describe('/api/multiple', function(){
                 .expect({'second': 'response'})
                 .end(helper.endCb(done));
         });
+
+        it('should respond with preferred status code', function(done) {
+            request.get('/api/multiple')
+                .set('Prefer', 'status=400')
+                .expect(400)
+                .expect('Content-type', 'application/json;charset=UTF-8')
+                .expect({'error': 'Bad request'})
+                .end(helper.endCb(done));
+        });
     });
 
     describe('POST', function(){

--- a/test/example/md/multiple-examples-api.md
+++ b/test/example/md/multiple-examples-api.md
@@ -38,7 +38,15 @@ Second GET example with header
     + Body
 
             {"second": "response"}
-            
+
+### Retrieve from GET [GET]
+Get examples with a specific status code (eg. 400)
+
++ Response 400 (application/json;charset=UTF-8)
+
+    + Body
+
+            {"error": "Bad request"}
 
 ### Post to the first example [POST]
 


### PR DESCRIPTION
Hi,

As per the discussion in http://support.apiary.io/forums/120125-general/suggestions/3264498-match-on-request-headers, here is an implementation allowing to pick a response from the spec by preferred status code. Insanely useful when developing against an error prone API!

Kind regards,
@SiCurious and @kosmotaur from noths.com