### PR TITLE
Discoverability

### DIFF
--- a/lib/arguments/arguments.js
+++ b/lib/arguments/arguments.js
@@ -43,6 +43,11 @@ module.exports = {
     },
     config: {
         description: 'Load configuration from a Javascript file, must export an object'
+    },
+    discover: {
+        description: 'List all available endpoints under `/`. If it\'s a module name, it will be required and called to create a middleware function to handle `/`.',
+        alias: 'D',
+        default: false
     }
 
 };

--- a/lib/drakov.js
+++ b/lib/drakov.js
@@ -26,8 +26,22 @@ exports.run = function(argv, cb) {
         if (err) {
             throw err;
         }
+
+        var discoverabilityModule;
+
         app.use(middlewareFunction);
         server = setup.startServer(argv, app, cb);
+        if (argv.discover && typeof argv.discover === 'string') {
+            discoverabilityModule = require(argv.discover);
+        }
+        else {
+            app.set('views', 'views');
+            app.set('view engine', 'jade');
+            discoverabilityModule = require('./middleware/discover');
+        }
+        if (argv.discover) {
+            app.get('/', discoverabilityModule(argv));
+        }
     });
 };
 

--- a/lib/middleware/discover.js
+++ b/lib/middleware/discover.js
@@ -1,0 +1,21 @@
+var buildRouteMap = require('./route-map');
+
+module.exports = function(sourceFiles) {
+    return function(req, res, next) {
+        if (res.headersSent) {
+            next();
+        }
+        else {
+            buildRouteMap(sourceFiles, function(err, routeMap) {
+                if (err) {
+                    next(err);
+                }
+                else {
+                    res.render('discover', {
+                        routes: Object.keys(routeMap)
+                    });
+                }
+            });
+        }
+    };
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "colors": "^1.1.0",
     "express": "^4.12.3",
     "glob": "^5.0.5",
+    "jade": "^1.11.0",
     "lodash": "^3.8.0",
     "optimist": "0.6.1",
     "path-to-regexp": "^1.0.3",

--- a/test/api/discover-test.js
+++ b/test/api/discover-test.js
@@ -1,0 +1,92 @@
+var helper = require('../lib');
+var request = helper.getRequest();
+
+describe('Discover', function() {
+    describe('Simple-API', function() {
+        describe('Discover option true', function() {
+            before(function(done) {
+                helper.drakov.run({sourceFiles: 'test/example/md/simple-api.md', discover: true}, done);
+            });
+
+            after(function(done) {
+                helper.drakov.stop(done);
+            });
+
+            describe('/', function() {
+                describe('GET', function() {
+                    it('should get discover page', function(done) {
+                        request.get('/')
+                            .expect(200)
+                            .expect('Content-type', 'text/html; charset=utf-8')
+                            .end(helper.endCb(done));
+                    });
+                });
+            });
+        });
+        describe('Discover option not specified', function() {
+            before(function(done) {
+                helper.drakov.run({sourceFiles: 'test/example/md/simple-api.md'}, done);
+            });
+
+            after(function(done) {
+                helper.drakov.stop(done);
+            });
+
+            describe('/', function() {
+                describe('GET', function() {
+                    it('should get 404', function(done) {
+                        request.get('/')
+                            .expect(404)
+                            .end(helper.endCb(done));
+                    });
+                });
+            });
+        });
+    });
+
+    describe('Root-Level-API', function() {
+        describe('Discover option not specified', function() {
+            before(function(done) {
+                helper.drakov.run({sourceFiles: 'test/example/md/root-level-api.md'}, done);
+            });
+
+            after(function(done) {
+                helper.drakov.stop(done);
+            });
+
+            describe('/', function() {
+                describe('GET', function() {
+                    it('should get root level request rather than discover page', function(done) {
+                        request.get('/')
+                            .expect(200)
+                            .expect('Content-type', 'application/json;charset=UTF-8')
+                            .expect({Slash: 'http://images5.fanpop.com/image/photos/31200000/Slash-slash-31278382-1707-2560.jpg'})
+                            .end(helper.endCb(done));
+                    });
+                });
+            });
+        });
+
+        describe('Discover option true', function() {
+            before(function(done) {
+                helper.drakov.run({sourceFiles: 'test/example/md/root-level-api.md', discover: true}, done);
+            });
+
+            after(function(done) {
+                helper.drakov.stop(done);
+            });
+
+            describe('/', function() {
+                describe('GET', function() {
+                    it('should get root level request rather than discover page', function(done) {
+                        request.get('/')
+                            .expect(200)
+                            .expect('Content-type', 'application/json;charset=UTF-8')
+                            .expect({Slash: 'http://images5.fanpop.com/image/photos/31200000/Slash-slash-31278382-1707-2560.jpg'})
+                            .end(helper.endCb(done));
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/example/md/root-level-api.md
+++ b/test/example/md/root-level-api.md
@@ -1,0 +1,11 @@
+
+## Slash [/]
+
+### Retrieve Slash [GET]
+
++ Response 200 (application/json;charset=UTF-8)
+
+    + Body
+            {
+                "Slash": "http://images5.fanpop.com/image/photos/31200000/Slash-slash-31278382-1707-2560.jpg"
+            }

--- a/views/discover.jade
+++ b/views/discover.jade
@@ -1,0 +1,7 @@
+extends layout
+block content
+    h1= 'Available endpoints'
+    ul
+        - routes.forEach(function(route) {
+            li= route
+        - });

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,0 +1,6 @@
+doctype html
+html
+    head
+        title= 'Drakov'
+    body
+        block content


### PR DESCRIPTION
Hi!

We've created a basic discover page. The use case is, that if we serve the blueprints on our internal network, and people visit its URL, it has been voiced that they could very much use a listing of all the endpoints exposed.

It is a bit rudimentary, and we plan on utilising Aglio to make it a beaut, but didn't want to introduce a dependency that big into Drakov. That's why the `-D` option accepts a string value, which would be the module to require to build the middleware to handle the discover page. We'll build that module separately.

Kind regards,
@SiCurious and @kosmotaur