### PR TITLE
FAQ Update: reference example how to request specific response

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Due to protagonist parsing being async, we need to setup the middleware with an 
 
 **Q:** If I have multiple requests/responses on the same API endpoint, which response will I get?
 
-**A:** Drakov will respond first with any responses that have a JSON schema with the first response matching the request body for that API endpoint. You can request a specific response by adding a `Prefer` header to the request in the form `Prefer:status=XXX` where `XXX` is the status code of the desired response.
+**A:** Drakov will respond first with any responses that have a JSON schema with the first response matching the request body for that API endpoint. You can request a specific response by adding a `Prefer` header to the request in the form `Prefer:status=XXX` where `XXX` is the status code of the desired response.  See [issue #88](https://github.com/Aconex/drakov/issues/88) for details.
 
 
 **Q:** If I have multiple responses on a single request, which response will I get?


### PR DESCRIPTION
Just a proposal: I believe it is nice if the answer in the FAQ on "how to request specific response" includes a reference to the issue that discusses how to do it