### PR TITLE
Use an absolute path for views

### DIFF
--- a/lib/drakov.js
+++ b/lib/drakov.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var path = require('path');
 require('colors');
 
 var logger = require('./logger');
@@ -34,7 +35,7 @@ exports.run = function(argv, cb) {
         if (argv.discover && typeof argv.discover === 'string') {
             discoverabilityModule = require(argv.discover);
         } else {
-            app.set('views', 'views');
+            app.set('views', path.join(__dirname, '..', 'views'));
             app.set('view engine', 'jade');
             discoverabilityModule = require('./middleware/discover');
         }


### PR DESCRIPTION
Without this patch, I was getting the following error when navigating to /drakov in discover mode: `Error: Failed to lookup view "discover" in views directory "views"`. This resolves that error by calculating the proper absolute views path.