### PR TITLE
compatibility with credentialed requests

### DIFF
--- a/lib/middleware/response.js
+++ b/lib/middleware/response.js
@@ -19,7 +19,8 @@ exports.drakovHeaders = function(req, res, next) {
 exports.corsHeaders = function(disableCORS) {
     return function(req, res, next) {
         if (!disableCORS) {
-            res.set('Access-Control-Allow-Origin', '*');
+            res.set('Access-Control-Allow-Origin', req.headers.origin || '*');
+            res.set('Access-Control-Allow-Credentials', 'true');
             res.set('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
         }
         next();


### PR DESCRIPTION
In order that drakov supports credentialed requests there needs to be some tweaks to the control headers.
For example to use drakov together with the HAL browser this change is needed because the HAL browser can only send credentialed requests.