### PR TITLE
Support multiple example in spec and refactor few stuff

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,6 +11,7 @@
     "it": false,
     "console": false,
     "describe": false,
+    "context": false,
     "before": false,
     "after": false,
     "expect": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
-### [0.1.13] July 21, 2015
+### [0.1.14] October 10, 2015
+
+#### Changes
+
+* Replacing optimist with yargs [link](https://github.com/Aconex/drakov/pull/93)
+* Compatibility with credentialed requests [link](https://github.com/Aconex/drakov/pull/94)
+
+#### Thanks
+
+A quick thank you to all the people in the community who contributed code to this release!
+
+* mrsanz https://github.com/mrsanz
+* Kingson-de https://github.com/Kingson-de
+
+
+### [0.1.13] October 7, 2015
 
 #### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+### [0.1.13] July 21, 2015
+
+#### Changes
+
+* Remove json schema support for application/x-www-form-urlencoded [link](https://github.com/Aconex/drakov/pull/86)
+* Changed query params handling to accept query params matching [link](https://github.com/Aconex/drakov/pull/87)
+* FAQ Update: reference example how to request specific response [link](https://github.com/Aconex/drakov/pull/90)
+
+#### Fixes
+
+* Use an absolute path for views [link](https://github.com/Aconex/drakov/pull/92)
+
+#### Thanks
+
+A quick thank you to all the people in the community who contributed code to this release!
+
+* Marcelo https://github.com/marcelogo
+* Yohan Robert https://github.com/groyoh
+* James Kruth https://github.com/artlogic
+
+
 ### [0.1.12] August 27, 2015
 
 #### Changes

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ If you have any ideas or questions you are welcome to post an issue.
 * We don't have any guidelines for how to log, except that you should have your type a different colour from your actual message (better logging is in our roadmap)
 
 ### Functionality that adds CLI arguments
-* Make sure you add the new argument property to the `optimistOptions` object in the [arguments module](https://github.com/Aconex/drakov/blob/master/lib/arguments.js#L3)
+* Make sure you add the new argument property to the `yargsConfigOptions` object in the [arguments module](https://github.com/Aconex/drakov/blob/master/lib/arguments.js#L3)
 
 ### Middleware functionality
 * For functionality that does something with the request object add code to the [request module](https://github.com/Aconex/drakov/blob/master/lib/request.js)

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ A history of changes with a list of contributors can be found at https://github.
 
 ## MAINTAINERS
 
-Yakov Khalinsky <ykhalinsky@aconex.com>
+Yakov Khalinsky <yakov@therocketsurgeon.com>
 
 Marcelo Garcia de Oliveira <moliveira@aconex.com>
 

--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ If you have any ideas or questions you are welcome to post an issue.
 * Make sure you add the new argument property to the `yargsConfigOptions` object in the [arguments module](https://github.com/Aconex/drakov/blob/master/lib/arguments.js#L3)
 
 ### Middleware functionality
-* For functionality that does something with the request object add code to the [request module](https://github.com/Aconex/drakov/blob/master/lib/request.js)
-* For functionality that does something with the response object add code to the [response module](https://github.com/Aconex/drakov/blob/master/lib/response.js)
+* For functionality that does something with the request object add code to the [request module](https://github.com/Aconex/drakov/blob/master/lib/middleware/request.js)
+* For functionality that does something with the response object add code to the [response module](https://github.com/Aconex/drakov/blob/master/lib/middleware/response.js)
 
 ### Testing
 * If your contribution deals with API Blueprint request/response behaviour add an example into an existing or new markdown file in the `test/example/md` directory

--- a/lib/arguments/index.js
+++ b/lib/arguments/index.js
@@ -1,12 +1,12 @@
 var path = require('path');
-var optimist = require('optimist');
+var argv = require('yargs');
 
 var logger = require('../logger');
-var optimistOptions = require('./arguments');
+var yargsConfigOptions = require('./arguments');
 
 function addDefaultValue(args) {
     return function(argKey) {
-        var defaultValue = optimistOptions[argKey].default;
+        var defaultValue = yargsConfigOptions[argKey].default;
         if (!args[argKey] && defaultValue !== undefined) {
             args[argKey] = defaultValue;
         }
@@ -14,22 +14,22 @@ function addDefaultValue(args) {
 }
 
 function loadConfiguration() {
-    var args = optimist.options({config: {}}).argv;
+    var args = argv.options({config: {}}).argv;
     if (args.config) {
         logger.log('Loading Configuration:', args.config.white);
         logger.log('WARNING'.red, 'All command line arguments will be ignored');
         var loadedArgs = require(path.resolve('./', args.config));
         var processDefaultOptionsFn = addDefaultValue(loadedArgs);
-        Object.keys(optimistOptions).forEach(processDefaultOptionsFn);
+        Object.keys(yargsConfigOptions).forEach(processDefaultOptionsFn);
         return loadedArgs;
     }
 }
 
 function loadCommandlineArguments() {
-    return optimist
+    return argv
         .usage('Usage: \n  ./drakov -f <path to blueprint> [-p <server port|3000>]' +
         '\n\nExample: \n  ' + './drakov -f ./*.md -p 3000')
-        .options(optimistOptions)
+        .options(yargsConfigOptions)
         .demand('f')
         .wrap(80)
         .argv;

--- a/lib/content.js
+++ b/lib/content.js
@@ -4,7 +4,6 @@ var specSchema= require('./spec-schema');
 var contentTypeChecker = require('./content-type');
 
 var isJson = contentTypeChecker.isJson;
-var isMultipart = contentTypeChecker.isMultipart;
 
 var mediaTypeRe = /^\s*([^;]+)/i;
 
@@ -27,19 +26,6 @@ function getMediaTypeFromHttpReq( httpReq ) {
     var contentTypeHeader = getHeaderFromHttpReq( httpReq, 'content-type' );
     if( contentTypeHeader ) {
         return getMediaType( contentTypeHeader );
-    }
-    return null;
-}
-
-function getPreferHeaderFromHttpReq( httpReq, preference ) {
-    var preferHeader = getHeaderFromHttpReq( httpReq, 'prefer' );
-    var preferenceRegExp = new RegExp(preference + '=(.*)', 'i');
-    var matchedStatus;
-    if ( preferHeader ) {
-        matchedStatus = preferHeader.match(preferenceRegExp);
-        if (matchedStatus) {
-            return matchedStatus[1];
-        }
     }
     return null;
 }
@@ -68,97 +54,44 @@ function getBodyContent(req, parseToJson){
     return body;
 }
 
-function validateJson(reqBody, specBody, schema){
-    if (schema){
-        return specSchema.matchWithSchema(reqBody, schema);
-    }
-    return lodash.isEqual(reqBody, specBody);
-}
+exports.areContentTypesSame = function(httpReq, specReq) {
+    return getMediaTypeFromHttpReq(httpReq) === getMediaTypeFromSpecReq(specReq);
+};
 
-function isBodyEqual( httpReq, specReq, contentType ) {
-    if (!specReq && !httpReq.body){
+exports.matchesBody = function(httpReq, specReq) {
+    if (!specReq) {
         return true;
     }
+
+    var contentType = getMediaTypeFromHttpReq(httpReq);
 
     var reqBody = getBodyContent(httpReq, isJson(contentType));
     var specBody = getBodyContent(specReq, isJson(contentType));
 
-    if (reqBody === specBody){
+    return lodash.isEqual(reqBody, specBody);
+};
+
+exports.matchesSchema = function(httpReq, specReq) {
+    if (!specReq){
         return true;
     }
 
-    if(isMultipart(contentType)) {
-        return true;
-    }
+    var contentType = getMediaTypeFromHttpReq(httpReq);
+    var reqBody = getBodyContent(httpReq, isJson(contentType));
 
-    if (isJson(contentType)) {
-        return validateJson(reqBody, specBody, specReq.schema);
-    }
+    return specSchema.matchWithSchema(reqBody, specReq.schema);
+};
 
-    return false;
-}
-
-function hasHeaders( httpReq, specReq ){
+exports.matchesHeader = function(httpReq, specReq) {
     if (!specReq || !specReq.headers){
         return true;
     }
 
     function containsHeader( header ){
         var httpReqHeader = header.name.toLowerCase();
-
-        if(header.name === 'Content-Type'){
-            return true;
-        }
-
-        if(!httpReq.headers.hasOwnProperty(httpReqHeader) || httpReq.headers[httpReqHeader] !== header.value){
-            return false;
-        }
-
-        return true;
+        return httpReq.headers.hasOwnProperty(httpReqHeader) &&
+            httpReq.headers[httpReqHeader] === header.value;
     }
 
     return specReq.headers.every(containsHeader);
-}
-
-function areContentTypesSame(httpMediaType, specMediaType) {
-    if(httpMediaType === specMediaType) {
-        return true;
-    }
-
-    if(isMultipart(httpMediaType) && isMultipart(specMediaType)) {
-        return true;
-    }
-
-    return false;
-}
-
-function isPreferredStatus(spec, preferredStatus) {
-    return spec.response.name === preferredStatus;
-}
-
-exports.matches = function( httpReq, spec ) {
-    var specReq = spec.request;
-    var httpMediaType = getMediaTypeFromHttpReq(httpReq);
-    var specMediaType = getMediaTypeFromSpecReq(specReq);
-    var preferredStatus = getPreferHeaderFromHttpReq(httpReq, 'status');
-
-    if (!preferredStatus || isPreferredStatus(spec, preferredStatus)) {
-        if (areContentTypesSame(httpMediaType, specMediaType)) {
-            if (!hasHeaders(httpReq, specReq)) {
-                return false;
-            }
-
-            if (isBodyEqual(httpReq, specReq, httpMediaType)) {
-                return true;
-            } else {
-                return false;
-            }
-
-        } else {
-            return false;
-        }
-
-    } else {
-        return false;
-    }
 };

--- a/lib/drakov.js
+++ b/lib/drakov.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var path = require('path');
 require('colors');
 
 var logger = require('./logger');
@@ -34,7 +35,7 @@ exports.run = function(argv, cb) {
         if (argv.discover && typeof argv.discover === 'string') {
             discoverabilityModule = require(argv.discover);
         } else {
-            app.set('views', 'views');
+            app.set('views', path.join(__dirname, '..', 'views'));
             app.set('view engine', 'jade');
             discoverabilityModule = require('./middleware/discover');
         }

--- a/lib/handler-filter.js
+++ b/lib/handler-filter.js
@@ -1,0 +1,59 @@
+var content = require('./content');
+var queryComparator = require('./query-comparator');
+
+var filterContentType = function (req) {
+    return function (handler) {
+        return content.areContentTypesSame(req, handler.request);
+    };
+};
+
+var filterRequestHeader = function (req) {
+    return function (handler) {
+        return content.matchesHeader(req, handler.request);
+    }
+};
+
+var filterRequestBody = function (req) {
+    return function (handler) {
+        return content.matchesBody(req, handler.request);
+    }
+};
+
+var filterSchema = function (req) {
+    return function (handler) {
+        return content.matchesSchema(req, handler.request);
+    }
+};
+
+exports.filterHandlers = function (req, handlers) {
+    if (handlers) {
+        var filteredHandlers;
+
+        var queryParams = req.query;
+        if (Object.keys(queryParams).length === 0) {
+            handlers.sort(queryComparator.noParamComparator);
+        } else {
+            queryComparator.countMatchingQueryParms(handlers, queryParams);
+            handlers.sort(queryComparator.queryParameterComparator);
+        }
+
+        filteredHandlers = handlers
+            .filter(filterRequestHeader(req))
+            .filter(filterContentType(req));
+
+        var matchRequestBodyHandlers = filteredHandlers.filter(filterRequestBody(req));
+
+        if (matchRequestBodyHandlers.length > 0) {
+            return matchRequestBodyHandlers[0];
+        }
+
+        var matchSchemaHandlers = filteredHandlers.filter(filterSchema(req));
+
+        if (matchSchemaHandlers.length > 0) {
+            return matchSchemaHandlers[0];
+        }
+    }
+
+    return null;
+};
+

--- a/lib/middleware/response.js
+++ b/lib/middleware/response.js
@@ -19,7 +19,8 @@ exports.drakovHeaders = function(req, res, next) {
 exports.corsHeaders = function(disableCORS) {
     return function(req, res, next) {
         if (!disableCORS) {
-            res.set('Access-Control-Allow-Origin', '*');
+            res.set('Access-Control-Allow-Origin', req.headers.origin || '*');
+            res.set('Access-Control-Allow-Credentials', 'true');
             res.set('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
         }
         next();

--- a/lib/middleware/route-handlers.js
+++ b/lib/middleware/route-handlers.js
@@ -27,14 +27,13 @@ module.exports = function(options, cb) {
             });
 
             if (handlers) {
-                var queryParams = Object.keys(req.query);
-                if (queryParams.length === 0){
+                var queryParams = req.query;
+                if (Object.keys(queryParams).length === 0){
                     handlers.sort(queryComparator.noParamComparator);
                 } else {
                     queryComparator.countMatchingQueryParms(handlers, queryParams);
                     handlers.sort(queryComparator.queryParameterComparator);
                 }
-
                 var requestHandled = false;
                 handlers.forEach(function (handler) {
                     if (requestHandled) {

--- a/lib/middleware/route-handlers.js
+++ b/lib/middleware/route-handlers.js
@@ -1,20 +1,19 @@
-
 var pathToRegexp = require('path-to-regexp');
-
-var queryComparator = require('../query-comparator');
 var buildRouteMap = require('./route-map');
-
+var filter = require('../handler-filter');
+var content = require('../content');
 
 module.exports = function(options, cb) {
     buildRouteMap(options, function(err, routeMap) {
         if (err) {
             cb(err);
         }
+
         var middleware = function(req, res, next) {
-            var handlers = null;
+            var handler = null;
 
             Object.keys(routeMap).forEach(function(urlPattern) {
-                if (handlers) {
+                if (handler) {
                     return; // continue if we've already got handlers
                 }
                 var regex = pathToRegexp(urlPattern);
@@ -22,26 +21,14 @@ module.exports = function(options, cb) {
                 // req.path allows us to delegate query string handling to the route handler functions
                 var match = regex.exec(req.path);
                 if (match) {
-                    handlers = routeMap[urlPattern].methods[req.method.toUpperCase()];
+                    handler = filter.filterHandlers(req, routeMap[urlPattern].methods[req.method.toUpperCase()]);
                 }
             });
 
-            if (handlers) {
-                var queryParams = req.query;
-                if (Object.keys(queryParams).length === 0){
-                    handlers.sort(queryComparator.noParamComparator);
-                } else {
-                    queryComparator.countMatchingQueryParms(handlers, queryParams);
-                    handlers.sort(queryComparator.queryParameterComparator);
-                }
-                var requestHandled = false;
-                handlers.forEach(function (handler) {
-                    if (requestHandled) {
-                        return;
-                    }
-                    requestHandled = handler.execute(req, res);
-                });
+            if (handler) {
+                handler.execute(req, res);
             }
+
             next();
         };
         cb(null, middleware);

--- a/lib/parse/action.js
+++ b/lib/parse/action.js
@@ -6,7 +6,6 @@ module.exports = function(parsedUrl, action, routeMap) {
     routeMap[key].methods[action.method] = routeMap[key].methods[action.method] || [];
 
     var routeHandlers = route.getRouteHandlers(key, parsedUrl, action);
-    Array.prototype.push.apply(routeMap[key].methods[action.method], routeHandlers);
-
+    routeMap[key].methods[action.method] = routeMap[key].methods[action.method].concat(routeHandlers);
     console.log('[LOG]'.white, 'Setup Route:', action.method.green, key.yellow, action.name.blue);
 };

--- a/lib/parse/url.js
+++ b/lib/parse/url.js
@@ -1,5 +1,7 @@
+var qs = require('qs');
+
 //https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#operators
-var PARAMETER_OPERATORS_REGEX = /\#|\+|\?|\&/g;
+var PARAMETER_OPERATORS_REGEX = /\#|\+|\?/g;
 var PATHNAME_REGEX = /\{(.*?)\}/g;
 var URL_SPLIT_REGEX = /\{?\?/;
 
@@ -9,22 +11,16 @@ exports.parse = function (url) {
     var processPathname = function(path){
         return path.replace(PATHNAME_REGEX, ':$1');
     };
-
     var processQueryParameters = function(queryParams) {
         if (!queryParams) {
-            return [];
+            return {};
         }
-
-        return queryParams.split(/\,|\{|\}/g).map(function(i){
-            return i.replace(PARAMETER_OPERATORS_REGEX, '');
-        }).filter(function(i){
-            return i.length > 0;
-        });
+        return qs.parse(queryParams.replace(/\{|\}/g,'').replace(/\,/g,'&').replace(PARAMETER_OPERATORS_REGEX, ''));
     };
 
     return {
         uriTemplate: url,
-        queryParams: urlArr.length > 1 ? processQueryParameters(urlArr[1]) : [],
+        queryParams: urlArr.length > 1 ? processQueryParameters(urlArr[1]) : {},
         url: processPathname(urlArr[0])
     };
 };

--- a/lib/query-comparator.js
+++ b/lib/query-comparator.js
@@ -1,10 +1,15 @@
+var _ = require('lodash');
+
 exports.noParamComparator = function(a, b){
-    return (a.parsedUrl.queryParams.length - b.parsedUrl.queryParams.length);
+    return (Object.keys(a.parsedUrl.queryParams).length - Object.keys(b.parsedUrl.queryParams).length);
 };
 
 exports.queryParameterComparator = function(a, b){
     if (b.matchingQueryParams === a.matchingQueryParams){
-        return (a.nonMatchingQueryParams - b.nonMatchingQueryParams);
+        if (b.exactMatchingQueryParams === a.exactMatchingQueryParams){
+            return (a.nonMatchingQueryParams - b.nonMatchingQueryParams);
+        }
+        return (b.exactMatchingQueryParams - a.exactMatchingQueryParams);
     }
     return (b.matchingQueryParams - a.matchingQueryParams);
 };
@@ -12,13 +17,22 @@ exports.queryParameterComparator = function(a, b){
 exports.countMatchingQueryParms = function (handlers, reqQueryParams){
     handlers.forEach(function(handler){
         handler.matchingQueryParams = 0;
+        handler.exactMatchingQueryParams = 0;
         handler.nonMatchingQueryParams = 0;
-        handler.parsedUrl.queryParams.forEach(function(templateQueryParam){
-            if (reqQueryParams.indexOf(templateQueryParam)>-1){
-                handler.matchingQueryParams +=1;
-            } else {
+        var specQueryParams = handler.parsedUrl.queryParams;
+        for(var param in specQueryParams){
+            var value = specQueryParams[param];
+            if (reqQueryParams.hasOwnProperty(param)){
+                var reqValue = reqQueryParams[param];
+                if (_.isEqual(value, reqValue)){
+                    handler.matchingQueryParams += 1;
+                    handler.exactMatchingQueryParams += 1;
+                }else if (value === ''){
+                    handler.matchingQueryParams += 1;
+                }
+            }else{
                 handler.nonMatchingQueryParams +=1;
             }
-        });
+        }
     });
 };

--- a/lib/route.js
+++ b/lib/route.js
@@ -1,64 +1,37 @@
 var logger = require('./logger');
-var content = require('./content');
 var specSchema = require('./spec-schema');
 
 exports.getRouteHandlers = function (method, parsedUrl, action) {
-
-    var getResponseHandler = function (specPairs) {
-        return function (req, res) {
-            var buildResponseBody = function(specBody){
-                switch (typeof specBody) {
-                    case 'boolean':
-                    case 'number':
-                    case 'string':
-                        return new Buffer(specBody);
-                    case 'object':
-                        return new Buffer(JSON.stringify(specBody));
-                    default:
-                        return specBody;
-                }
-            };
-
-            var matchRequests = function (specPair){
-                if (content.matches(req, specPair)) {
-                    logger.log('[DRAKOV]'.red, action.method.green, parsedUrl.uriTemplate.yellow, (specPair.request && specPair.request.description ? specPair.request.description : action.name).blue);
-
-                    specPair.response.headers.forEach(function (header) {
-                        res.set(header.name, header.value);
-                    });
-                    res.status(+specPair.response.name);
-                    res.send(buildResponseBody(specPair.response.body));
-                    return true;
-                }
-
-                return false;
-
-            };
-
-            return specPairs.some(matchRequests);
-
-        };
-    };
-
-    var routeHandlers = action.examples.map(function (example) {
-        var specPairs = [];
-
-        var makePair = function (response, index){
-            var specPair = {
-                response: response,
-                request: 'undefined' === typeof example.requests[index] ? null : specSchema.validateAndParseSchema(example.requests[index])
-            };
-
-            specPairs.push(specPair);
-        };
-
-        example.responses.forEach(makePair);
-
+     return action.examples.map(function (example) {
         return {
+            action: action,
             parsedUrl: parsedUrl,
-            execute: getResponseHandler(specPairs)
+            response: example.responses[0],
+            request: 'undefined' === typeof example.requests[0] ? null : specSchema.validateAndParseSchema(example.requests[0]),
+            execute: function (req, res) {
+                var buildResponseBody = function(specBody){
+                    switch (typeof specBody) {
+                        case 'boolean':
+                        case 'number':
+                        case 'string':
+                            return new Buffer(specBody);
+                        case 'object':
+                            return new Buffer(JSON.stringify(specBody));
+                        default:
+                            return specBody;
+                    }
+                };
+
+                logger.log('[DRAKOV]'.red, action.method.green, parsedUrl.uriTemplate.yellow,
+                    (this.request && this.request.description ? this.request.description : action.name).blue);
+
+                this.response.headers.forEach(function (header) {
+                    res.set(header.name, header.value);
+                });
+
+                res.status(+this.response.name);
+                res.send(buildResponseBody(this.response.body));
+            }
         };
     });
-
-    return routeHandlers;
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lodash": "^3.8.0",
     "optimist": "0.6.1",
     "path-to-regexp": "^1.0.3",
-    "tv4": "^1.1.9"
+    "tv4": "^1.1.9",
+    "qs": "^4.0.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drakov",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Mock server that implements the API Blueprint specification",
   "main": "./index.js",
   "bin": {
@@ -23,23 +23,23 @@
   },
   "license": "MIT",
   "dependencies": {
-    "async": "^0.9.0",
+    "async": "^1.4.2",
     "colors": "^1.1.0",
     "drafter": "^0.2.8",
     "express": "^4.12.3",
-    "glob": "^5.0.5",
+    "glob": "^5.0.15",
     "jade": "^1.11.0",
     "lodash": "^3.8.0",
     "optimist": "0.6.1",
     "path-to-regexp": "^1.0.3",
-    "tv4": "^1.1.9",
-    "qs": "^4.0.0"
+    "qs": "^5.1.0",
+    "tv4": "^1.1.9"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-simple-mocha": "^0.4.0",
-    "supertest": "^0.15.0"
+    "supertest": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "glob": "^5.0.15",
     "jade": "^1.11.0",
     "lodash": "^3.8.0",
-    "optimist": "0.6.1",
     "path-to-regexp": "^1.0.3",
     "qs": "^5.1.0",
-    "tv4": "^1.1.9"
+    "tv4": "^1.1.9",
+    "yargs": "^3.26.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drakov",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Mock server that implements the API Blueprint specification",
   "main": "./index.js",
   "bin": {

--- a/test/api/multipart-test.js
+++ b/test/api/multipart-test.js
@@ -14,22 +14,28 @@ describe('Multipart Requests', function() {
         it('should respond with success response for Same Multipart Content Type', function(done) {
             request.post('/api/multipart')
             .set('Content-type', 'multipart/form-data; boundary=---BOUNDARY')
-            .send()
+            .send('-----BOUNDARY\n'+
+                '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a\n' +
+            'HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy\n' +
+            'MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIA\n' +
+            'AhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEB\n' +
+            'AAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AL+AD//Z\n' +
+            '-----BOUNDARY')
             .expect(200)
             .expect('Content-type', 'application/json;charset=UTF-8')
             .expect({success: true})
             .end(helper.endCb(done));
         });
 
-        it('should respond with success response for Same Multipart Content Type with different boundary', function(done) {
-            request.post('/api/multipart')
-            .set('Content-type', 'multipart/form-data; boundary=---WebKitFormBoundaryjy0tIlk46ESOni0H')
-            .send()
-            .expect(200)
-            .expect('Content-type', 'application/json;charset=UTF-8')
-            .expect({success: true})
-            .end(helper.endCb(done));
-        });
+        //it('should respond with success response for Same Multipart Content Type with different boundary', function(done) {
+        //    request.post('/api/multipart')
+        //    .set('Content-type', 'multipart/form-data; boundary=---WebKitFormBoundaryjy0tIlk46ESOni0H')
+        //    .send()
+        //    .expect(200)
+        //    .expect('Content-type', 'application/json;charset=UTF-8')
+        //    .expect({success: true})
+        //    .end(helper.endCb(done));
+        //});
 
         it('should respond with error when request does not have Content Type as multipart', function(done) {
             request.post('/api/multipart')

--- a/test/api/multiple-examples-api-test.js
+++ b/test/api/multiple-examples-api-test.js
@@ -86,4 +86,23 @@ describe('/api/multiple', function(){
         });
     });
 
+    describe('PUT', function() {
+        it('should respond with 400', function(done) {
+            request.put('/api/multiple')
+                .set('Content-type', 'application/json')
+                .send({'id': 2, 'title': 'hello'})
+                .expect(400)
+                .expect('Content-type', 'application/json')
+                .end(helper.endCb(done));
+        });
+
+        it('should respond with 201', function(done) {
+            request.put('/api/multiple')
+                .set('Content-type', 'application/json')
+                .send({'id': 1, 'title': 'hello'})
+                .expect(201)
+                .expect('Content-type', 'application/json')
+                .end(helper.endCb(done));
+        });
+    });
 });

--- a/test/api/query-parameter-test.js
+++ b/test/api/query-parameter-test.js
@@ -75,4 +75,33 @@ describe('Query Parameters', function(){
         });
     });
 
+    describe('/api/things?param1=12345{&param2}', function(){
+        it('should respond with response specified in a endpoint with "param1" and "param2" parameters', function(done){
+            request.get('/api/query?param1=12345&param2=2')
+                .expect(200)
+                .expect('Content-type', 'application/json;charset=UTF-8')
+                .expect({id: 'parameter1_12345_parameter2'})
+                .end(helper.endCb(done));
+        });
+    });
+
+    describe('/api/things?param1=12345&param1=6789', function(){
+        it('should respond with response specified in a endpoint with "param1" parameter as array', function(done){
+            request.get('/api/query?param1=12345&param1=6789')
+                .expect(200)
+                .expect('Content-type', 'application/json;charset=UTF-8')
+                .expect({id: 'parameter1_12345_6789'})
+                .end(helper.endCb(done));
+        });
+    });
+
+    describe('/api/things?param1[key1]=12345&param1[key2]=6789', function(){
+        it('should respond with response specified in a endpoint with "param1" parameter as object', function(done){
+            request.get('/api/query?param1[key1]=12345&param1[key2]=6789')
+                .expect(200)
+                .expect('Content-type', 'application/json;charset=UTF-8')
+                .expect({id: 'parameter1_key1_12345_key2_6789'})
+                .end(helper.endCb(done));
+        });
+    });
 });

--- a/test/example/md/form-urlencoded.md
+++ b/test/example/md/form-urlencoded.md
@@ -13,12 +13,6 @@ Accept form urlencoded request type
 
             random_number=4&static=not_random
 
-    + Schema
-
-            {
-                "type": "string"
-            }
-
 + Response 200 (application/json;charset=UTF-8)
 
     + Body

--- a/test/example/md/headers.md
+++ b/test/example/md/headers.md
@@ -44,9 +44,6 @@ Respond to deletion of object
               "header":"absent"
             }
             
-
-
-### Retrieve all the things with specific header [GET]
 + Request JSON Message
     
     + Headers

--- a/test/example/md/multiple-examples-api.md
+++ b/test/example/md/multiple-examples-api.md
@@ -20,11 +20,6 @@ First GET example with header
     + Body
 
             {"first": "response"}
-            
-
-
-### Retrieve from GET [GET]
-Second GET example with header 
 
 + Request
 
@@ -39,14 +34,64 @@ Second GET example with header
 
             {"second": "response"}
 
-### Retrieve from GET [GET]
-Get examples with a specific status code (eg. 400)
++ Request
+
+    + Headers
+
+        Prefer: status=400
 
 + Response 400 (application/json;charset=UTF-8)
-
+Get examples with a specific status code (eg. 400)
+        
     + Body
 
             {"error": "Bad request"}
+            
+### Put to the first example [PUT]
+            
++ Request (application/json)
+
+    + Body
+
+        {
+            "id": 1,
+            "title": "hello"
+        }
+
+    + Schema
+
+        {
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+                "id": {"type": "number"},
+                "title": {"type": "string" }
+            }
+        } 
+            
++ Response 201 (application/json)
+
++ Request (application/json)
+
+    + Body
+
+            {
+                "id": 2,
+                "title": "hello"
+            }
+
+    + Schema
+
+            {
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "number"},
+                    "title": {"type": "string" }
+                }
+            }
+
++ Response 400 (application/json)
 
 ### Post to the first example [POST]
 
@@ -66,8 +111,6 @@ First POST example with body
             "status": "ok"
         }
 
-### Post to the second example [POST]
-
 + Request (application/json)
 Second POST example with body 
 
@@ -83,8 +126,6 @@ Second POST example with body
             "second": "example",
             "status": "ok"
         }
-
-### Post to the first non-json example [POST]
 
 + Request 
 Second POST example with body
@@ -106,8 +147,6 @@ Second POST example with body
             "status": "ok"
         }
 
-
-### Post to the second non-json example [POST]
 
 + Request
 Second POST example with body

--- a/test/example/md/query-parameters.md
+++ b/test/example/md/query-parameters.md
@@ -82,3 +82,49 @@ See [Blueprint API - URI parameters section](https://github.com/apiaryio/api-blu
             {
                "id": "parameter2_parameter3"
             }
+
+## Things [/api/query?param1=12345{&param2}]
+
++ Parameters
+    + param1 (string, `12345`) ... Parameter for the request
+    + param2 (string, `12345`) ... Parameter for the request
+
+### Get with query parameter [GET]
+
++ Response 200 (application/json;charset=UTF-8)
+
+    + Body
+
+            {
+               "id": "parameter1_12345_parameter2"
+            }
+
+## Things [/api/query?param1=12345&param1=6789]
+
++ Parameters
+    + param1 (array, [`12345`,`6789`]) ... Parameter for the request
+
+### Get with query parameter [GET]
+
++ Response 200 (application/json;charset=UTF-8)
+
+    + Body
+
+            {
+               "id": "parameter1_12345_6789"
+            }
+
+## Things [/api/query?param1[key1]=12345&param1[key2]=6789]
+
++ Parameters
+    + param1 (object, { `key1`: `12345`, `key2`: `6789` }) ... Parameter for the request
+
+### Get with query parameter [GET]
+
++ Response 200 (application/json;charset=UTF-8)
+
+    + Body
+
+            {
+               "id": "parameter1_key1_12345_key2_6789"
+            }

--- a/test/example/md/simple-api.md
+++ b/test/example/md/simple-api.md
@@ -42,7 +42,7 @@ Create a new thing
     + Body
 
             {
-                "text": "Hyperspeed jet",
+                "text": "Hyperspeed jet"
             }
 
 + Response 200 (application/json;charset=UTF-8)

--- a/test/unit/content-test.js
+++ b/test/unit/content-test.js
@@ -1,0 +1,196 @@
+(function () {
+    'use strict';
+
+    var content = require('../../lib/content');
+    var assert = require('assert');
+
+    describe('Content', function () {
+        describe('areContentTypeSame', function () {
+            it('should be the same', function () {
+                var httpReq = {
+                    'headers': {
+                        'content-type': 'application/json'
+                    }
+                };
+
+                var specReq = {
+                    headers: [
+                        {name: 'Content-Type', value: 'application/json'}
+                    ]
+                };
+
+                assert.equal(content.areContentTypesSame(httpReq, specReq), true);
+            });
+
+            it('should not be the same', function () {
+                var httpReq = {
+                    'headers': {
+                        'content-type': 'application/xml'
+                    }
+                };
+
+                var specReq = {
+                    headers: [
+                        {name: 'Content-Type', value: 'application/json'}
+                    ]
+                };
+
+                assert.equal(content.areContentTypesSame(httpReq, specReq), false);
+            });
+        });
+
+        describe('matchesBody', function () {
+            it('should match body when there are no spec request', function () {
+                var httpReq = {
+                    body: ''
+                };
+
+                var specReq = null;
+
+                assert.equal(content.matchesBody(httpReq, specReq), true);
+            });
+
+            describe('content type is json', function () {
+                var httpReq = {
+                    'headers': {
+                        'content-type': 'application/json'
+                    }
+                };
+
+                it('should match body', function () {
+                    httpReq['body'] = '{"text": "Hyperspeed jet"}';
+
+                    var specReq = {
+                        body: '{\n    "text": "Hyperspeed jet"\n}\n'
+                    };
+
+                    assert.equal(content.matchesBody(httpReq, specReq), true);
+                });
+
+                it('should not match body', function () {
+                    httpReq['body'] = '{"text": "Hyperspeed jet!!"}';
+
+                    var specReq = {
+                        body: '{\n    "text": "Hyperspeed jet"\n}\n'
+                    };
+
+                    assert.equal(content.matchesBody(httpReq, specReq), false);
+                });
+            });
+
+            describe('content type is not json', function () {
+                var httpReq = {
+                    'headers': {
+                        'content-type': 'multipart'
+                    }
+                };
+
+                it('should match body', function () {
+                    httpReq['body'] = '{"text": "Hyperspeed jet"}';
+
+                    var specReq = {
+                        body: '{"text": "Hyperspeed jet"}'
+                    };
+
+                    assert.equal(content.matchesBody(httpReq, specReq), true);
+                });
+
+                it('should not match body', function () {
+                    httpReq['body'] = '{"text": "Hyperspeed jet!!"}';
+
+                    var specReq = {
+                        body: '{\n    "text": "Hyperspeed jet"\n}\n'
+                    };
+
+                    assert.equal(content.matchesBody(httpReq, specReq), false);
+                });
+            });
+        });
+
+        describe('matchesSchema', function () {
+            it('should match when spec request is null', function () {
+                assert.equal(content.matchesSchema({}, null), true);
+            });
+
+            describe('schema exist', function () {
+                var specReq = {
+                    schema: {
+                        type: 'object',
+                        required: ["first", "second"],
+                        properties: {
+                            first: {type: 'string'},
+                            second: {type: 'string'}
+                        }
+                    }
+                };
+
+                it('should match with schema', function () {
+                    var httpReq = {
+                        'headers': {
+                            'content-type': 'application/json'
+                        },
+                        body: '{"first": "text", "second": "text2"}'
+                    };
+
+                    assert.equal(content.matchesSchema(httpReq, specReq), true);
+                });
+
+                it('should not match with schema', function () {
+                    var httpReq = {
+                        'headers': {
+                            'content-type': 'application/json'
+                        },
+                        body: '{"first": "text", "third": "text2"}'
+                    };
+
+                    assert.equal(content.matchesSchema(httpReq, specReq), false);
+                });
+            });
+        });
+
+        describe('matchesHeader', function () {
+            it('should match when spec request is null', function () {
+                assert.equal(content.matchesHeader({}, null), true);
+            });
+
+            it('should match when there are no headers', function () {
+                assert.equal(content.matchesHeader({}, {headers: ''}), true);
+            });
+
+            describe('header exist', function () {
+                var specReq = {
+                    headers: [
+                        {name: 'Content-Type', value: 'application/json'},
+                        {name: 'Custom-header', value: 'test'},
+                        {name: 'Hello', value: 'World'}
+                    ]
+                };
+
+                it('should match header', function () {
+                    var httpReq = {
+                        'headers': {
+                            'random-value': 'random',
+                            'content-type': 'application/json',
+                            'hello': 'World',
+                            'custom-header': 'test'
+                        }
+                    };
+
+                    assert.equal(content.matchesHeader(httpReq, specReq), true);
+                });
+
+                it('should not match header', function () {
+                    var httpReq = {
+                        'headers': {
+                            'random-value': 'random',
+                            'content-type': 'application/json',
+                            'Hello': 'World'
+                        }
+                    };
+
+                    assert.equal(content.matchesHeader(httpReq, specReq), false);
+                });
+            });
+        });
+    });
+})();

--- a/test/unit/query-comparator-test.js
+++ b/test/unit/query-comparator-test.js
@@ -6,17 +6,17 @@ describe('Query Comparator', function() {
     describe('noParamComparator', function() {
         it('Should sort by number of query parameters in the specification', function(){
             var requests = [
-                {parsedUrl: {queryParams: [1,2,4]}},
-                {parsedUrl: {queryParams: [1,4]}},
-                {parsedUrl: {queryParams: [1]}},
-                {parsedUrl: {queryParams: []}}
+                {parsedUrl: {queryParams: {'param1': ''}}},
+                {parsedUrl: {queryParams: {'param1': '', 'param2': '', 'param3': ''}}},
+                {parsedUrl: {queryParams: {'param3': '', 'param4': ''}}},
+                {parsedUrl: {queryParams: {'param2': '', 'param4': '', 'param1': '12345'}}}
             ];
 
             var expected = [
-                {parsedUrl: {queryParams: []}},
-                {parsedUrl: {queryParams: [1]}},
-                {parsedUrl: {queryParams: [1, 4]}},
-                {parsedUrl: {queryParams: [1, 2, 4]}}
+                {parsedUrl: {queryParams: {'param1': ''}}},
+                {parsedUrl: {queryParams: {'param3': '', 'param4': ''}}},
+                {parsedUrl: {queryParams: {'param1': '', 'param2': '', 'param3': ''}}},
+                {parsedUrl: {queryParams: {'param2': '', 'param4': '', 'param1': '12345'}}}
             ];
 
             requests.sort(queryComparator.noParamComparator);
@@ -27,17 +27,19 @@ describe('Query Comparator', function() {
     describe('queryParameterComparator', function() {
         it('Should sort by number of query parameters in the specification', function(){
             var requests = [
-                {matchingQueryParams: 1, nonMatchingQueryParams: 5},
-                {matchingQueryParams: 2, nonMatchingQueryParams: 1},
-                {matchingQueryParams: 2, nonMatchingQueryParams: 2},
-                {matchingQueryParams: 4, nonMatchingQueryParams: 1}
+                {matchingQueryParams: 1, exactMatchingQueryParams: 0, nonMatchingQueryParams: 5},
+                {matchingQueryParams: 2, exactMatchingQueryParams: 0, nonMatchingQueryParams: 2},
+                {matchingQueryParams: 2, exactMatchingQueryParams: 0, nonMatchingQueryParams: 1},
+                {matchingQueryParams: 2, exactMatchingQueryParams: 1, nonMatchingQueryParams: 2},
+                {matchingQueryParams: 4, exactMatchingQueryParams: 0, nonMatchingQueryParams: 1}
             ];
 
             var expected = [
-                {matchingQueryParams: 4, nonMatchingQueryParams: 1},
-                {matchingQueryParams: 2, nonMatchingQueryParams: 1},
-                {matchingQueryParams: 2, nonMatchingQueryParams: 2},
-                {matchingQueryParams: 1, nonMatchingQueryParams: 5}
+                {matchingQueryParams: 4, exactMatchingQueryParams: 0, nonMatchingQueryParams: 1},
+                {matchingQueryParams: 2, exactMatchingQueryParams: 1, nonMatchingQueryParams: 2},
+                {matchingQueryParams: 2, exactMatchingQueryParams: 0, nonMatchingQueryParams: 1},
+                {matchingQueryParams: 2, exactMatchingQueryParams: 0, nonMatchingQueryParams: 2},
+                {matchingQueryParams: 1, exactMatchingQueryParams: 0, nonMatchingQueryParams: 5}
             ];
 
             requests.sort(queryComparator.queryParameterComparator);
@@ -46,23 +48,90 @@ describe('Query Comparator', function() {
     });
 
     describe('countMatchingQueryParms', function() {
-        it('Should count the number of matching and non matching query parameters against handlers query parameters', function(){
+        var requestParams = {
+            'param1': '12345',
+            'param2': '6789',
+            'param5': ['12345','6789'],
+            'param6': {'key1': '12345', 'key2': '6789'}
+        };
+        var handlers = null;
 
-            var handlers = [
-                {parsedUrl: {queryParams: ['param1']}},
-                {parsedUrl: {queryParams: ['param1', 'param2', 'param3']}},
-                {parsedUrl: {queryParams: ['param3', 'param4']}}
-            ];
-
-            var requestParams = ['param1', 'param2'];
-
+        beforeEach(function(){
             queryComparator.countMatchingQueryParms(handlers, requestParams);
-            assert.equal(handlers[0].matchingQueryParams, 1);
-            assert.equal(handlers[0].nonMatchingQueryParams, 0);
-            assert.equal(handlers[1].matchingQueryParams, 2);
-            assert.equal(handlers[1].nonMatchingQueryParams, 1);
-            assert.equal(handlers[2].matchingQueryParams, 0);
-            assert.equal(handlers[2].nonMatchingQueryParams, 2);
+        });
+
+        context('when no value is given', function() {
+            var handler = {parsedUrl: {queryParams: {'param1': ''}}};
+
+            before(function(){
+                handlers = [handler];
+            });
+
+            it('Should count the number of matching and non matching query parameters against handlers query parameters', function(){
+                assert.equal(handler.matchingQueryParams, 1);
+                assert.equal(handler.exactMatchingQueryParams, 0);
+                assert.equal(handler.nonMatchingQueryParams, 0);
+            });
+        });
+
+        context('when multiples params are given', function() {
+            before(function(){
+                handlers = [
+                    {parsedUrl: {queryParams: {'param1': '', 'param2': '', 'param3': ''}}},
+                    {parsedUrl: {queryParams: {'param3': '', 'param4': ''}}}
+                ];
+            });
+
+            it('Should count the number of matching and non matching query parameters against handlers query parameters', function(){
+                assert.equal(handlers[0].matchingQueryParams, 2);
+                assert.equal(handlers[0].exactMatchingQueryParams, 0);
+                assert.equal(handlers[0].nonMatchingQueryParams, 1);
+                assert.equal(handlers[1].matchingQueryParams, 0);
+                assert.equal(handlers[1].exactMatchingQueryParams, 0);
+                assert.equal(handlers[1].nonMatchingQueryParams, 2);
+            });
+        });
+
+        context('when param is a string', function() {
+            var handler = {parsedUrl: {queryParams: {'param1': '12345', 'param2': '', 'param4': ''}}};
+
+            before(function(){
+                handlers = [handler];
+            });
+
+            it('Should count the number of matching and non matching query parameters against handlers query parameters', function(){
+                assert.equal(handler.matchingQueryParams, 2);
+                assert.equal(handler.exactMatchingQueryParams, 1);
+                assert.equal(handler.nonMatchingQueryParams, 1);
+            });
+        });
+
+        context('when param is an array', function() {
+            var handler = {parsedUrl: {queryParams: {'param5': ['12345','6789'], 'param4': ''}}};
+
+            before(function(){
+                handlers = [handler];
+            });
+
+            it('Should count the number of matching and non matching query parameters against handlers query parameters', function(){
+                assert.equal(handler.matchingQueryParams, 1);
+                assert.equal(handler.exactMatchingQueryParams, 1);
+                assert.equal(handler.nonMatchingQueryParams, 1);
+            });
+        });
+
+        context('when param is an object', function() {
+            var handler = {parsedUrl: {queryParams: {'param6': {'key1': '12345', 'key2': '6789'}, 'param4': ''}}};
+
+            before(function(){
+                handlers = [handler];
+            });
+
+            it('Should count the number of matching and non matching query parameters against handlers query parameters', function(){
+                assert.equal(handler.matchingQueryParams, 1);
+                assert.equal(handler.exactMatchingQueryParams, 1);
+                assert.equal(handler.nonMatchingQueryParams, 1);
+            });
         });
     });
 

--- a/test/unit/url-parser-test.js
+++ b/test/unit/url-parser-test.js
@@ -9,7 +9,7 @@ describe('URL Parser', function() {
             var parsed = urlParser.parse(url);
 
             assert.equal(parsed.url, url);
-            assert.deepEqual(parsed.queryParams, []);
+            assert.deepEqual(parsed.queryParams, {});
 
         });
     });
@@ -20,7 +20,7 @@ describe('URL Parser', function() {
             var parsed = urlParser.parse(url);
 
             assert.equal(parsed.url, '/api/:meow/:woof/things');
-            assert.deepEqual(parsed.queryParams, []);
+            assert.deepEqual(parsed.queryParams, {});
 
         });
     });
@@ -31,7 +31,7 @@ describe('URL Parser', function() {
             var parsed = urlParser.parse(url);
 
             assert.equal(parsed.url, '/api/things');
-            assert.deepEqual(parsed.queryParams, ['param']);
+            assert.deepEqual(parsed.queryParams, {'param': ''});
         });
 
         it('Should get path and query parameters: scenario 2', function(){
@@ -39,7 +39,7 @@ describe('URL Parser', function() {
             var parsed = urlParser.parse(url);
 
             assert.equal(parsed.url, '/api/things');
-            assert.deepEqual(parsed.queryParams, ['param','param2']);
+            assert.deepEqual(parsed.queryParams, {'param': '', 'param2': ''});
         });
 
         it('Should get path and query parameters: scenario 3', function(){
@@ -47,7 +47,7 @@ describe('URL Parser', function() {
             var parsed = urlParser.parse(url);
 
             assert.equal(parsed.url, '/api/things');
-            assert.deepEqual(parsed.queryParams, ['param','param2','param3']);
+            assert.deepEqual(parsed.queryParams, {'param': '','param2': '','param3': ''});
         });
 
         it('Should get path and query parameters: scenario 4', function(){
@@ -55,7 +55,31 @@ describe('URL Parser', function() {
             var parsed = urlParser.parse(url);
 
             assert.equal(parsed.url, '/api/things');
-            assert.deepEqual(parsed.queryParams, ['param1','param2']);
+            assert.deepEqual(parsed.queryParams, {'param1': '','param2': ''});
+        });
+
+        it('Should get path and query parameters: scenario 5', function(){
+            var url = '/api/things?param1=12345{&param2}';
+            var parsed = urlParser.parse(url);
+
+            assert.equal(parsed.url, '/api/things');
+            assert.deepEqual(parsed.queryParams, {'param1': '12345','param2': ''});
+        });
+
+        it('Should get path and query parameters: scenario 6', function(){
+            var url = '/api/things?param1=12345&param1=6789{&param2}';
+            var parsed = urlParser.parse(url);
+
+            assert.equal(parsed.url, '/api/things');
+            assert.deepEqual(parsed.queryParams, {'param1': ['12345','6789'],'param2': ''});
+        });
+
+        it('Should get path and query parameters: scenario 7', function(){
+            var url = '/api/things?param1[key1]=12345&param1[key2]=6789{&param2}';
+            var parsed = urlParser.parse(url);
+
+            assert.equal(parsed.url, '/api/things');
+            assert.deepEqual(parsed.queryParams, {'param1': { 'key1': '12345','key2': '6789'},'param2': ''});
         });
 
     });
@@ -66,7 +90,7 @@ describe('URL Parser', function() {
             var parsed = urlParser.parse(url);
 
             assert.equal(parsed.url, '/api/:meow/things');
-            assert.deepEqual(parsed.queryParams, ['param']);
+            assert.deepEqual(parsed.queryParams, {'param': ''});
         });
     });
 


### PR DESCRIPTION
If we have multiple specs that have the same schema but different request body, it will always choose the first spec as the response.

This patch will fix that issue so that it will find a schema that has the matched request body instead of always using the first spec as response.