### PR TITLE
Support newer versions of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
+sudo: required
+dist: trusty
 language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "4"
+  - "5"
 notifications:
   email:
     - yakov@therocketsurgeon.com

--- a/lib/parse/blueprint.js
+++ b/lib/parse/blueprint.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var Drafter = require('drafter');
+var protagonist = require('protagonist');
 var _ = require('lodash');
 var urlParser = require('./url');
 var parseParameters = require('./parameters');
@@ -9,8 +9,8 @@ var autoOptionsAction = require('../json/auto-options-action.json');
 module.exports = function(filePath, autoOptions, routeMap) {
     return function(cb) {
         var data = fs.readFileSync(filePath, {encoding: 'utf8'});
-        var drafter = new Drafter();
-        drafter.make(data, function(err, result) {
+        var options = { type: 'ast' };
+        protagonist.parse(data, options, function(err, result) {
             if (err) {
                 console.log(err);
                 return;

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   "dependencies": {
     "async": "^1.4.2",
     "colors": "^1.1.0",
-    "drafter": "^0.2.8",
     "express": "^4.12.3",
     "glob": "^5.0.15",
     "jade": "^1.11.0",
     "lodash": "^3.8.0",
     "path-to-regexp": "^1.0.3",
+    "protagonist": "^1.2.0",
     "qs": "^5.1.0",
     "tv4": "^1.1.9",
     "yargs": "^3.26.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jade": "^1.11.0",
     "lodash": "^3.8.0",
     "path-to-regexp": "^1.0.3",
-    "protagonist": "^1.2.0",
+    "protagonist": "^1.2.2",
     "qs": "^5.1.0",
     "tv4": "^1.1.9",
     "yargs": "^3.26.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-blueprint-validator": "^2.0.5",
+    "grunt-blueprint-validator": "^2.1.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-simple-mocha": "^0.4.0",

--- a/test/api/mson-api-test.js
+++ b/test/api/mson-api-test.js
@@ -16,9 +16,7 @@ describe('MSON-API', function(){
                 request.get('/api/things')
                 .expect(200)
                 .expect('Content-type', 'application/json;charset=UTF-8')
-                .expect([
-                    {text:'Zip2',id: '1'}
-                ])
+                .expect([{text:'Zip2',id: '1'}])
                 .end(helper.endCb(done));
             });
         });
@@ -30,8 +28,7 @@ describe('MSON-API', function(){
                 request.get('/api/things/1111')
                 .expect(200)
                 .expect('Content-type', 'application/json;charset=UTF-8')
-                .expect([{text: 'Zip2', id: '1'}
-                    ])
+                .expect([{text: 'Zip2', id: '1'}])
                 .end(helper.endCb(done));
             });
         });
@@ -40,10 +37,10 @@ describe('MSON-API', function(){
             it('should respond with json object from contract example', function(done){
                 request.post('/api/things/1111')
                 .set('Content-type', 'application/json')
-                .send({ text: 'Zip2', id: '1' })
+                .send([{ text: 'Zip2', id: '1' }])
                 .expect(200)
                 .expect('Content-type', 'application/json;charset=UTF-8')
-                .expect({ text: 'Zip2', id: '1' })
+                .expect([{ text: 'Zip2', id: '1' }])
                 .end(helper.endCb(done));
             });
         });

--- a/test/example/md/mson-api.md
+++ b/test/example/md/mson-api.md
@@ -23,7 +23,6 @@ Create a new thing
     + Attributes (object)
         + text: Hyperspeed jet (string)
 
-
 + Response 200 (application/json;charset=UTF-8)
 
     + Attributes (object)
@@ -50,14 +49,14 @@ Create a new thing
 
 ### Update thing by it's id [POST]
 
-+ Request ( application/json)
++ Request (application/json)
 Update the text of the thing
 
-    + Attributes (Things)
+    + Attributes (array[Things])
 
 + Response 200 (application/json;charset=UTF-8)
 
-    + Attributes (Things)
+    + Attributes (array[Things])
 
 ## Likes [/api/things/{thingId}/like]
 


### PR DESCRIPTION
Created based on https://github.com/Aconex/drakov/pull/107
Used a newer version of travis image (https://docs.travis-ci.com/user/trusty-ci-environment/) that has by default g++ 4.8 needed for node 4 and 5
Added travis tests on node 4 and 5