### PR TITLE
Add support for automaticlly loading configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ supported in the [arguments module](https://github.com/Aconex/drakov/blob/master
 
 All command line arguments aside from `--config` will be ignored, and the defaults will be merged in.
 
+## Running with .drakovrc configuration file
+
+`drakov`
+
+Similar to utilities such as JSHint, drakov will look for a `.drakovrc` file in the current path where `drakov` is executed
+and walk up the path until `/` is reached.
+
+The `.drakovrc` file should be a valid Node.js module that exports a valid Drakov configuration object such as would be
+used with the `--config` switch.
+
 
 ## API discovery
 

--- a/lib/arguments/index.js
+++ b/lib/arguments/index.js
@@ -4,6 +4,8 @@ var argv = require('yargs');
 var logger = require('../logger');
 var yargsConfigOptions = require('./arguments');
 
+var RC_FILE = '.drakovrc';
+
 function addDefaultValue(args) {
     return function(argKey) {
         var defaultValue = yargsConfigOptions[argKey].default;
@@ -16,16 +18,46 @@ function addDefaultValue(args) {
 function loadConfiguration() {
     var args = argv.options({config: {}}).argv;
     if (args.config) {
-        logger.log('Loading Configuration:', args.config.white);
-        logger.log('WARNING'.red, 'All command line arguments will be ignored');
-        var loadedArgs = require(path.resolve('./', args.config));
-        var processDefaultOptionsFn = addDefaultValue(loadedArgs);
-        Object.keys(yargsConfigOptions).forEach(processDefaultOptionsFn);
-        return loadedArgs;
+        return loadConfigFromModule(args.config, '');
+    } else {
+        var paths = getPathsFromCwd();
+        for (var i = 0; i < paths.length; i++) {
+            var config = loadConfigFromModule(RC_FILE, paths[i]);
+            if (config) {
+                return config;
+            }
+        }
+        return loadConfigFromModule(RC_FILE, process.cwd());
     }
 }
 
+function loadConfigFromModule(filePath, cwd) {
+    var searchPath = path.resolve(cwd + filePath);
+    var loadedArgs;
+    try {
+        loadedArgs = require(searchPath);
+    } catch (e) {
+        return;
+    }
+    logger.log('Loading Configuration:', searchPath.white);
+    logger.log('WARNING'.red, 'All command line arguments will be ignored');
+    var processDefaultOptionsFn = addDefaultValue(loadedArgs);
+    Object.keys(yargsConfigOptions).forEach(processDefaultOptionsFn);
+    return loadedArgs;
+}
+
+function getPathsFromCwd() {
+    var pathComponents = process.cwd().split('/');
+    var paths = [];
+    for (var i = pathComponents.length; i > 0; i--) {
+        paths.push(pathComponents.slice(0, i).concat(['']).join('/'));
+    }
+    return paths;
+}
+
 function loadCommandlineArguments() {
+    console.log('[INFO]'.white, 'No configuration files found');
+    console.log('[INFO]'.white, 'Loading configuration from CLI');
     return argv
         .usage('Usage: \n  ./drakov -f <path to blueprint> [-p <server port|3000>]' +
         '\n\nExample: \n  ' + './drakov -f ./*.md -p 3000')


### PR DESCRIPTION
Adding support for loading from `.drakovrc`

Will walk the path all the way until `/` is reached looking for a `.drakovrc` configuration file.

Referencing issue #112 