### PR TITLE
Replace Protagonist with Drafter.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "4"
   - "5"

--- a/examples/express-middleware.js
+++ b/examples/express-middleware.js
@@ -11,7 +11,7 @@ drakovOptions  = {
     sourceFiles: '../test/example/**/*.md'
 };
 
-// currently need to initialise the middleware asynchronously due to protagonist parse in async
+// currently need to initialise the middleware asynchronously due to drafter parse in async
 drakovMiddleware.init(app, drakovOptions, function(err, middlewareFunction) {
     if (err) {
         throw err;

--- a/lib/parse/blueprint.js
+++ b/lib/parse/blueprint.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var protagonist = require('protagonist');
+var drafter = require('drafter.js');
 var _ = require('lodash');
 var urlParser = require('./url');
 var parseParameters = require('./parameters');
@@ -10,7 +10,7 @@ module.exports = function(filePath, autoOptions, routeMap) {
     return function(cb) {
         var data = fs.readFileSync(filePath, {encoding: 'utf8'});
         var options = { type: 'ast' };
-        protagonist.parse(data, options, function(err, result) {
+        drafter.parse(data, options, function(err, result) {
             if (err) {
                 console.log(err);
                 return cb(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drakov",
-  "version": "0.2.2",
+  "version": "0.2.2x",
   "description": "Mock server that implements the API Blueprint specification",
   "main": "./index.js",
   "bin": {
@@ -26,12 +26,12 @@
     "async": "^1.4.2",
     "chokidar": "^1.4.3",
     "colors": "^1.1.0",
+    "drafter.js": "^2.2.0",
     "express": "^4.13.4",
     "glob": "^7.0.3",
     "jade": "^1.11.0",
     "lodash": "^4.6.1",
     "path-to-regexp": "^1.0.3",
-    "protagonist": "^1.2.6",
     "qs": "^6.1.0",
     "tv4": "^1.1.9",
     "yargs": "^4.2.0"


### PR DESCRIPTION
Once Protagonist is gone from Drakov and it's dependencies, there will be no more C compilation required during npm install. :+1: 