### PR TITLE
Allow drafter to upgrade to minor versions which are compatible with 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "async": "^1.4.2",
     "chokidar": "^1.4.3",
     "colors": "^1.1.0",
-    "drafter.js": "^2.2.0",
+    "drafter.js": "^2.0.0",
     "express": "^4.13.4",
     "glob": "^7.0.3",
     "jade": "^1.11.0",


### PR DESCRIPTION
Looks like the latest compatible drafter.js version (2.4.3) is *much* faster at parsing API Blueprint files. Any chance you could bump a minor version and allow that update?