### PR TITLE
Log request matching process for better problem diagnosis

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -59,7 +59,7 @@ exports.areContentTypesSame = function(httpReq, specReq) {
     var expected = getMediaTypeFromSpecReq(specReq);
 
     var result = actual === expected;
-    logger.log('[MATCHING]'.white,'Expected content type:', expected, 'actual:', actual, logger.stringfy(result));
+    logger.log('[MATCHING]'.yellow,'Expected content type:', expected, 'actual:', actual, logger.stringfy(result));
     return result;
 };
 
@@ -76,8 +76,10 @@ exports.matchesBody = function(httpReq, specReq) {
 
     var reqBody = getBodyContent(httpReq, isJson(contentType));
     var specBody = getBodyContent(specReq, isJson(contentType));
+    var result = lodash.isEqual(reqBody, specBody);
 
-    return lodash.isEqual(reqBody, specBody);
+    logger.log('[MATCHING]'.yellow,'by request body content', logger.stringfy(result));
+    return result;
 };
 
 exports.matchesSchema = function(httpReq, specReq) {
@@ -87,8 +89,9 @@ exports.matchesSchema = function(httpReq, specReq) {
 
     var contentType = getMediaTypeFromHttpReq(httpReq);
     var reqBody = getBodyContent(httpReq, isJson(contentType));
-
-    return specSchema.matchWithSchema(reqBody, specReq.schema);
+    var result =  specSchema.matchWithSchema(reqBody, specReq.schema);
+    logger.log('[MATCHING]'.yellow,'by request body schema', logger.stringfy(result));
+    return result;
 };
 
 exports.matchesHeader = function(httpReq, specReq) {
@@ -105,7 +108,7 @@ exports.matchesHeader = function(httpReq, specReq) {
         var result = httpReq.headers.hasOwnProperty(httpReqHeader)
           && httpReq.headers[httpReqHeader] === header.value;
 
-        logger.log('[MATCHING]'.white,'Expected header', httpReqHeader, '=', header.value, logger.stringfy(result));
+        logger.log('[MATCHING]'.yellow,'Expected header', httpReqHeader, '=', header.value, logger.stringfy(result));
         return result;
     }
 

--- a/lib/content.js
+++ b/lib/content.js
@@ -55,7 +55,12 @@ function getBodyContent(req, parseToJson){
 }
 
 exports.areContentTypesSame = function(httpReq, specReq) {
-    return getMediaTypeFromHttpReq(httpReq) === getMediaTypeFromSpecReq(specReq);
+    var actual = getMediaTypeFromHttpReq(httpReq);
+    var expected = getMediaTypeFromSpecReq(specReq);
+
+    var result = actual === expected;
+    logger.log('[MATCHING]'.white,'Expected content type:', expected, 'actual:', actual, logger.stringfy(result));
+    return result;
 };
 
 exports.matchesBody = function(httpReq, specReq) {
@@ -97,8 +102,11 @@ exports.matchesHeader = function(httpReq, specReq) {
 
     function containsHeader( header ){
         var httpReqHeader = header.name.toLowerCase();
-        return httpReq.headers.hasOwnProperty(httpReqHeader) &&
-            httpReq.headers[httpReqHeader] === header.value;
+        var result = httpReq.headers.hasOwnProperty(httpReqHeader)
+          && httpReq.headers[httpReqHeader] === header.value;
+
+        logger.log('[MATCHING]'.white,'Expected header', httpReqHeader, '=', header.value, logger.stringfy(result));
+        return result;
     }
 
     return specReq.headers.filter(removeContentTypeHeader).every(containsHeader);

--- a/lib/content.js
+++ b/lib/content.js
@@ -59,7 +59,7 @@ exports.areContentTypesSame = function(httpReq, specReq) {
     var expected = getMediaTypeFromSpecReq(specReq);
 
     var result = actual === expected;
-    logger.log('[MATCHING]'.yellow,'Expected content type:', expected, 'actual:', actual, logger.stringfy(result));
+    logger.log('[MATCHING]'.yellow,'by request content type:', expected, 'actual:', actual, logger.stringfy(result));
     return result;
 };
 
@@ -108,7 +108,7 @@ exports.matchesHeader = function(httpReq, specReq) {
         var result = httpReq.headers.hasOwnProperty(httpReqHeader)
           && httpReq.headers[httpReqHeader] === header.value;
 
-        logger.log('[MATCHING]'.yellow,'Expected header', httpReqHeader, '=', header.value, logger.stringfy(result));
+        logger.log('[MATCHING]'.yellow,'by request header', httpReqHeader, '=', header.value, logger.stringfy(result));
         return result;
     }
 

--- a/lib/content.js
+++ b/lib/content.js
@@ -105,8 +105,8 @@ exports.matchesHeader = function(httpReq, specReq) {
 
     function containsHeader( header ){
         var httpReqHeader = header.name.toLowerCase();
-        var result = httpReq.headers.hasOwnProperty(httpReqHeader)
-          && httpReq.headers[httpReqHeader] === header.value;
+        var result = httpReq.headers.hasOwnProperty(httpReqHeader) &&
+          httpReq.headers[httpReqHeader] === header.value;
 
         logger.log('[MATCHING]'.yellow,'by request header', httpReqHeader, '=', header.value, logger.stringfy(result));
         return result;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -14,5 +14,5 @@ exports.log = function() {
 };
 
 exports.stringfy = function(matched) {
-  return matched ? "MATCHED".green : "NOT_MATCHED".red;
+  return matched ? 'MATCHED'.green : 'NOT_MATCHED'.red;
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -12,3 +12,7 @@ exports.log = function() {
     }
     console.log(Array.prototype.slice.call(arguments).join(' '));
 };
+
+exports.stringfy = function(matched) {
+  return matched ? "MATCHED".green : "NOT_MATCHED".red;
+};

--- a/lib/middleware/route-handlers.js
+++ b/lib/middleware/route-handlers.js
@@ -20,7 +20,7 @@ module.exports = function(options, cb) {
 
                 // req.path allows us to delegate query string handling to the route handler functions
                 var match = regex.exec(req.path);
-                logger.log("[MATCHING]".white, "Matching with pattern:", urlPattern.yellow, logger.stringfy(match))
+                logger.log("[MATCHING]".yellow, "Matching with pattern:", urlPattern.yellow, logger.stringfy(match))
                 if (match) {
                     handler = filter.filterHandlers(req, routeMap[urlPattern].methods[req.method.toUpperCase()]);
                 }

--- a/lib/middleware/route-handlers.js
+++ b/lib/middleware/route-handlers.js
@@ -1,6 +1,7 @@
 var pathToRegexp = require('path-to-regexp');
 var buildRouteMap = require('./route-map');
 var filter = require('../handler-filter');
+var logger = require('../logger');
 
 module.exports = function(options, cb) {
     buildRouteMap(options, function(err, routeMap) {
@@ -19,6 +20,7 @@ module.exports = function(options, cb) {
 
                 // req.path allows us to delegate query string handling to the route handler functions
                 var match = regex.exec(req.path);
+                logger.log("[MATCHING]".white, "Matching with pattern:", urlPattern.yellow, logger.stringfy(match))
                 if (match) {
                     handler = filter.filterHandlers(req, routeMap[urlPattern].methods[req.method.toUpperCase()]);
                 }
@@ -32,4 +34,5 @@ module.exports = function(options, cb) {
         };
         cb(null, middleware);
     });
+
 };

--- a/lib/middleware/route-handlers.js
+++ b/lib/middleware/route-handlers.js
@@ -20,7 +20,7 @@ module.exports = function(options, cb) {
 
                 // req.path allows us to delegate query string handling to the route handler functions
                 var match = regex.exec(req.path);
-                logger.log("[MATCHING]".yellow, "Matching with pattern:", urlPattern.yellow, logger.stringfy(match))
+                logger.log('[MATCHING]'.yellow, 'by url pattern:', urlPattern.yellow, logger.stringfy(match));
                 if (match) {
                     handler = filter.filterHandlers(req, routeMap[urlPattern].methods[req.method.toUpperCase()]);
                 }


### PR DESCRIPTION
I found that it is pretty hard to find out why Drakov send back `404` instead of defined response, so I added these matching log to help diagnosis.
