### PR TITLE
Ignore content-type comparison when spec does not define it.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,6 +41,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-blueprint-validator');
 
+    grunt.task.registerTask('unit-test', ['simplemocha:unit']);
     grunt.task.registerTask('test', ['blueprint-validator', 'simplemocha:api', 'simplemocha:unit']);
     grunt.task.registerTask('default', ['jshint', 'test']);
 };

--- a/lib/content.js
+++ b/lib/content.js
@@ -54,8 +54,22 @@ function getBodyContent(req, parseToJson){
     return body;
 }
 
+exports.contentTypeComparator = function(specA) {
+
+    function hasContentTypeHeader(spec){
+        if (spec.request && spec.request.headers){
+            return spec.request.headers.filter(function(header){ return header.name.toLowerCase() === 'content-type';}).length > 0;
+        }
+        return false;
+    }
+
+    return !hasContentTypeHeader(specA)? 1 : -1;
+};
+
 exports.areContentTypesSame = function(httpReq, specReq) {
-    return getMediaTypeFromHttpReq(httpReq) === getMediaTypeFromSpecReq(specReq);
+    var specContentType = getMediaTypeFromSpecReq(specReq);
+
+    return !specContentType || getMediaTypeFromHttpReq(httpReq) === specContentType;
 };
 
 exports.matchesBody = function(httpReq, specReq) {

--- a/lib/handler-filter.js
+++ b/lib/handler-filter.js
@@ -29,6 +29,8 @@ exports.filterHandlers = function (req, handlers) {
     if (handlers) {
         var filteredHandlers;
 
+        handlers.sort(content.contentTypeComparator);
+
         var queryParams = req.query;
         if (Object.keys(queryParams).length === 0) {
             handlers.sort(queryComparator.noParamComparator);

--- a/test/api/content-type-test.js
+++ b/test/api/content-type-test.js
@@ -1,0 +1,39 @@
+var helper = require('../lib');
+var request = helper.getRequest();
+
+describe('Simple-API', function(){
+    before(function (done) {
+        helper.drakov.run({sourceFiles: 'test/example/md/content-type.md'}, done);
+    });
+
+    after(function (done) {
+        helper.drakov.stop(done);
+    });
+
+    describe('/api/content-type', function(){
+        describe('GET', function(){
+            it('should ignore content-type check when spec does not define it', function(done){
+                request.get('/api/content-type')
+                .set('Content-type', 'application/json')
+                .send({some: 'thing'})
+                .expect(200)
+                .expect('Content-type', 'application/json;charset=UTF-8')
+                .expect({response: 'ha'})
+                .end(helper.endCb(done));
+            });
+        });
+
+        describe('POST', function(){
+            it('should ignore content-type check when spec does not define it', function(done){
+                request.post('/api/content-type')
+                    .set('Content-type', 'application/json')
+                    .send({some: 'thing'})
+                    .expect(200)
+                    .expect('Content-type', 'application/json;charset=UTF-8')
+                    .expect({response: 'ha'})
+                    .end(helper.endCb(done));
+            });
+        });
+    });
+
+});

--- a/test/example/md/content-type.md
+++ b/test/example/md/content-type.md
@@ -1,0 +1,25 @@
+FORMAT: 1A
+
+# Requests without content-type
+
+## Content type API [/api/content-type]
+
+### Get some stuff [GET]
+
++ Response 200 (application/json;charset=UTF-8)
+
+    + Body
+
+            {
+              "response": "ha"
+            }
+            
+### Create some stuff  [POST]
+
++ Response 200 (application/json;charset=UTF-8)
+
+    + Body
+    
+            {
+              "response": "ha"
+            }

--- a/test/unit/content-test.js
+++ b/test/unit/content-test.js
@@ -5,7 +5,24 @@
     var assert = require('assert');
 
     describe('Content', function () {
-        describe('areContentTypeSame', function () {
+        describe('areContentTypesSame', function () {
+
+            it('should return true when spec does not define content-type the same', function () {
+                var httpReq = {
+                    'headers': {
+                        'content-type': 'application/json'
+                    }
+                };
+
+                var specReq = {
+                    headers: [
+                        {}
+                    ]
+                };
+
+                assert.equal(content.areContentTypesSame(httpReq, specReq), true);
+            });
+
             it('should be the same', function () {
                 var httpReq = {
                     'headers': {
@@ -38,6 +55,65 @@
                 assert.equal(content.areContentTypesSame(httpReq, specReq), false);
             });
         });
+
+        describe('contentTypeComparator', function () {
+            it('should return 1 when first spec does not contain content-type header', function () {
+                var specA = {
+                    request: {
+                        headers: [
+                            {name: 'Not-Content-Type', value: 'application/json'}
+                        ]
+                    }
+                };
+
+                var specB ={
+                    request: {
+                        headers: [
+                            {name: 'Content-Type', value: 'application/json'}
+                        ]
+                    }
+                };
+
+                assert.equal(content.contentTypeComparator(specA, specB), 1);
+            });
+
+            it('should return -1 when first spec contains content-type header', function () {
+                var specA = {
+                    request: {
+                        headers: [
+                            {name: 'Content-Type', value: 'application/json'}
+                        ]
+                    }
+                };
+
+                var specB ={
+                    request: {
+                        headers: [
+                            {name: 'Content-Type', value: 'application/json'}
+                        ]
+                    }
+                };
+
+                assert.equal(content.contentTypeComparator(specA, specB), -1);
+            });
+
+            it('should not be the same', function () {
+                var httpReq = {
+                    'headers': {
+                        'content-type': 'application/xml'
+                    }
+                };
+
+                var specReq = {
+                    headers: [
+                        {name: 'Content-Type', value: 'application/json'}
+                    ]
+                };
+
+                assert.equal(content.areContentTypesSame(httpReq, specReq), false);
+            });
+        });
+
 
         describe('matchesBody', function () {
             it('should match body when there are no spec request', function () {


### PR DESCRIPTION
This is an attempt to  make content-type matching less strict.

Refer to issue #136