### PR TITLE
support generate routes from dicectory

### DIFF
--- a/lib/arguments/arguments.js
+++ b/lib/arguments/arguments.js
@@ -1,7 +1,8 @@
 module.exports = {
     sourceFiles: {
         alias: 'f',
-        description: 'Glob expression to select spec files.'
+        description: 'Glob expression to select spec files.',
+        array: true
     },
     serverPort: {
         alias: 'p',

--- a/lib/middleware/route-map.js
+++ b/lib/middleware/route-map.js
@@ -1,4 +1,3 @@
-var glob = require('glob');
 var async = require('async');
 var parseBlueprint = require('../parse/blueprint');
 var endpointSorter = require('./endpoint-sorter');

--- a/lib/middleware/route-map.js
+++ b/lib/middleware/route-map.js
@@ -7,21 +7,13 @@ module.exports = function(options, cb) {
     var sourceFiles = options.sourceFiles;
     var autoOptions = options.autoOptions;
     var routeMap = {};
+    var asyncFunctions = [];
 
-    glob(sourceFiles, {} , function (err, files) {
-        if (err) {
-            console.error('Failed to parse contracts path.', err);
-            return cb(err);
-        }
+    sourceFiles.forEach(function(filePath) {
+        asyncFunctions.push(parseBlueprint(filePath, autoOptions, routeMap));
+    });
 
-        var asyncFunctions = [];
-
-        files.forEach(function(filePath) {
-            asyncFunctions.push(parseBlueprint(filePath, autoOptions, routeMap));
-        });
-
-        async.series(asyncFunctions, function(err) {
-            cb(err, endpointSorter.sort(routeMap));
-        });
+    async.series(asyncFunctions, function(err) {
+        cb(err, endpointSorter.sort(routeMap));
     });
 };

--- a/lib/parse/blueprint.js
+++ b/lib/parse/blueprint.js
@@ -5,6 +5,8 @@ var urlParser = require('./url');
 var parseParameters = require('./parameters');
 var parseAction = require('./action');
 var autoOptionsAction = require('../json/auto-options-action.json');
+var url = require('url');
+var urlPrefix;
 
 module.exports = function(filePath, autoOptions, routeMap) {
     return function(cb) {
@@ -17,6 +19,12 @@ module.exports = function(filePath, autoOptions, routeMap) {
             }
 
             var allRoutesList = [];
+            result.ast.metadata.forEach(function(el){
+              if (el.name === 'HOST') {
+                urlPrefix = url.parse(el.value).path;
+              }
+            });
+
             result.ast.resourceGroups.forEach(function(resourceGroup){
                 resourceGroup.resources.forEach(setupResourceAndUrl);
             });
@@ -30,7 +38,9 @@ module.exports = function(filePath, autoOptions, routeMap) {
 
             function setupResourceAndUrl(resource) {
                 var parsedUrl = urlParser.parse(resource.uriTemplate);
+                parsedUrl.url = (urlPrefix + parsedUrl.url);
                 var key = parsedUrl.url;
+
                 routeMap[key] = routeMap[key] || { urlExpression: key, methods: {} };
                 parseParameters(parsedUrl, resource.parameters, routeMap);
                 resource.actions.forEach(function(action){


### PR DESCRIPTION
When i pass a directory to `-f` argument, it will make `sourceFiles` options as the first file in this directory

```
➜  drakov git:(master) ./drakov -f /Users/changhong/code/apibay/shanbay/*.apib
[INFO] No configuration files found
[INFO] Loading configuration from CLI
{ _:
   [ '/Users/changhong/code/apibay/shanbay/checkin.apib',
     '/Users/changhong/code/apibay/shanbay/experiment.apib',
     '/Users/changhong/code/apibay/shanbay/flex.apib',
     '/Users/changhong/code/apibay/shanbay/harbor.apib',
     '/Users/changhong/code/apibay/shanbay/insurance.apib',
     '/Users/changhong/code/apibay/shanbay/live.apib',
     '/Users/changhong/code/apibay/shanbay/loong.apib',
     '/Users/changhong/code/apibay/shanbay/lottery.apib',
     '/Users/changhong/code/apibay/shanbay/media.apib',
     '/Users/changhong/code/apibay/shanbay/news.apib',
     '/Users/changhong/code/apibay/shanbay/notification.apib',
     '/Users/changhong/code/apibay/shanbay/pay.apib',
     '/Users/changhong/code/apibay/shanbay/people.apib',
     '/Users/changhong/code/apibay/shanbay/questionnaire.apib',
     '/Users/changhong/code/apibay/shanbay/quote.apib',
     '/Users/changhong/code/apibay/shanbay/report.apib',
     '/Users/changhong/code/apibay/shanbay/shop.apib',
     '/Users/changhong/code/apibay/shanbay/soup.apib',
     '/Users/changhong/code/apibay/shanbay/speak.apib',
     '/Users/changhong/code/apibay/shanbay/studyroom.apib',
     '/Users/changhong/code/apibay/shanbay/wechat_app.apib' ],
  f: '/Users/changhong/code/apibay/shanbay/academy.apib',
  sourceFiles: '/Users/changhong/code/apibay/shanbay/academy.apib',
  serverPort: 3000,
  p: 3000,
  public: false,
  discover: false,
  D: false,
  '$0': 'drakov',
  config: undefined,
  staticPaths: undefined,
  pathDelimiter: undefined,
  stealthmode: undefined,
  disableCORS: undefined,
  sslKeyFile: undefined,
  sslCrtFile: undefined,
  delay: undefined,
  method: undefined,
  header: undefined,
  autoOptions: undefined,
  watch: undefined }
```

I find that `yargs` did this.

With this PR, we can generate routes from single file or a directory.


## Add support for `HOST` metadata.
if there is a prefix path in the `HOST` meta, we add this prefix to the routes in express.

For example, 
```
HOST: https://www.shanbay.com/api/v2/test

## Login [/login/]

### Login [POST]

+ Response 200 (application/json)
    + Attributes (BaseSuccessResponse)
```

will have a route: `POST /api/v2/test/login/`
