### PR TITLE
Log request matching process for better problem diagnosis #2

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -67,9 +67,12 @@ exports.contentTypeComparator = function(specA) {
 };
 
 exports.areContentTypesSame = function(httpReq, specReq) {
-    var specContentType = getMediaTypeFromSpecReq(specReq);
+    var actual = getMediaTypeFromHttpReq(httpReq);
+    var expected = getMediaTypeFromSpecReq(specReq);
 
-    return !specContentType || getMediaTypeFromHttpReq(httpReq) === specContentType;
+    var result = !expected || actual === expected;
+    logger.log('[MATCHING]'.yellow,'by request content type:', expected, 'actual:', actual, logger.stringfy(result));
+    return result;
 };
 
 exports.matchesBody = function(httpReq, specReq) {
@@ -85,8 +88,10 @@ exports.matchesBody = function(httpReq, specReq) {
 
     var reqBody = getBodyContent(httpReq, isJson(contentType));
     var specBody = getBodyContent(specReq, isJson(contentType));
+    var result = lodash.isEqual(reqBody, specBody);
 
-    return lodash.isEqual(reqBody, specBody);
+    logger.log('[MATCHING]'.yellow,'by request body content', logger.stringfy(result));
+    return result;
 };
 
 exports.matchesSchema = function(httpReq, specReq) {
@@ -96,8 +101,9 @@ exports.matchesSchema = function(httpReq, specReq) {
 
     var contentType = getMediaTypeFromHttpReq(httpReq);
     var reqBody = getBodyContent(httpReq, isJson(contentType));
-
-    return specSchema.matchWithSchema(reqBody, specReq.schema);
+    var result =  specSchema.matchWithSchema(reqBody, specReq.schema);
+    logger.log('[MATCHING]'.yellow,'by request body schema', logger.stringfy(result));
+    return result;
 };
 
 exports.matchesHeader = function(httpReq, specReq) {
@@ -111,8 +117,11 @@ exports.matchesHeader = function(httpReq, specReq) {
 
     function containsHeader( header ){
         var httpReqHeader = header.name.toLowerCase();
-        return httpReq.headers.hasOwnProperty(httpReqHeader) &&
-            httpReq.headers[httpReqHeader] === header.value;
+        var result = httpReq.headers.hasOwnProperty(httpReqHeader) &&
+          httpReq.headers[httpReqHeader] === header.value;
+
+        logger.log('[MATCHING]'.yellow,'by request header', httpReqHeader, '=', header.value, logger.stringfy(result));
+        return result;
     }
 
     return specReq.headers.filter(removeContentTypeHeader).every(containsHeader);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -12,3 +12,7 @@ exports.log = function() {
     }
     console.log(Array.prototype.slice.call(arguments).join(' '));
 };
+
+exports.stringfy = function(matched) {
+  return matched ? 'MATCHED'.green : 'NOT_MATCHED'.red;
+};

--- a/lib/middleware/route-handlers.js
+++ b/lib/middleware/route-handlers.js
@@ -1,6 +1,7 @@
 var pathToRegexp = require('path-to-regexp');
 var buildRouteMap = require('./route-map');
 var filter = require('../handler-filter');
+var logger = require('../logger');
 
 module.exports = function(options, cb) {
     buildRouteMap(options, function(err, routeMap) {
@@ -19,6 +20,7 @@ module.exports = function(options, cb) {
 
                 // req.path allows us to delegate query string handling to the route handler functions
                 var match = regex.exec(req.path);
+                logger.log('[MATCHING]'.yellow, 'by url pattern:', urlPattern.yellow, logger.stringfy(match));
                 if (match) {
                     handler = filter.filterHandlers(req, routeMap[urlPattern].methods[req.method.toUpperCase()]);
                 }
@@ -32,4 +34,5 @@ module.exports = function(options, cb) {
         };
         cb(null, middleware);
     });
+
 };

--- a/test/example/md/query-parameters.md
+++ b/test/example/md/query-parameters.md
@@ -46,7 +46,7 @@ See [Blueprint API - URI parameters section](https://github.com/apiaryio/api-blu
                "id": "parameter2"
             }
 
-## Things [/api/query?param1{&param2}]
+## Things [/api/query?{param1}&{param2}]
 
 + Parameters
     + param1 (string, `12345`) ... Parameter for the request
@@ -79,7 +79,7 @@ See [Blueprint API - URI parameters section](https://github.com/apiaryio/api-blu
                "id": "parameter2_parameter3"
             }
 
-## Things [/api/query?param1=12345{&param2}]
+## Things [/api/query?{param1}=12345&{param2}]
 
 + Parameters
     + param1 (string, `12345`) ... Parameter for the request
@@ -95,7 +95,7 @@ See [Blueprint API - URI parameters section](https://github.com/apiaryio/api-blu
                "id": "parameter1_12345_parameter2"
             }
 
-## Things [/api/query?param1=12345&param1=6789]
+## Things [/api/query?{param1}=12345&{param1}=6789]
 
 + Parameters
     + param1 (array, `["12345","6789"]`) ... Parameter for the request
@@ -110,7 +110,7 @@ See [Blueprint API - URI parameters section](https://github.com/apiaryio/api-blu
                "id": "parameter1_12345_6789"
             }
 
-## Things [/api/query?param1%5Bkey1%5D=12345&param1%5Bkey2%5D=6789]
+## Things [/api/query?{param1}%5Bkey1%5D=12345&{param1}%5Bkey2%5D=6789]
 
 + Parameters
     + param1 (object) ... Parameter for the request

--- a/test/lib/stdout-hook.js
+++ b/test/lib/stdout-hook.js
@@ -1,0 +1,16 @@
+var exports = module.exports;
+
+exports.setup = function(callback) {
+    var write = process.stdout.write;
+
+    process.stdout.write = (function(stub) {
+        return  function(string, encoding, fd) {
+            stub.apply(process.stdout, arguments);
+            callback(string, encoding, fd);
+        };
+    })(process.stdout.write);
+
+    return function() {
+        process.stdout.write = write;
+    };
+};

--- a/test/unit/content-test.js
+++ b/test/unit/content-test.js
@@ -7,6 +7,14 @@
     var loadash = require('lodash');
 
     describe('Content', function () {
+
+        before(function (done) {
+           var helper = require('../lib/drakov-runner');
+           helper.run({stealthmode: false}, function () {
+               helper.stop(done);
+           });
+        });
+
         describe('areContentTypesSame', function () {
 
             var httpReq = {

--- a/test/unit/content-test.js
+++ b/test/unit/content-test.js
@@ -2,17 +2,20 @@
     'use strict';
 
     var content = require('../../lib/content');
+    var stdoutHook = require('../lib/stdout-hook');
     var assert = require('assert');
+    var loadash = require('lodash');
 
     describe('Content', function () {
         describe('areContentTypesSame', function () {
 
-            it('should return true when spec does not define content-type the same', function () {
-                var httpReq = {
-                    'headers': {
-                        'content-type': 'application/json'
-                    }
-                };
+            var httpReq = {
+                'headers': {
+                    'content-type': 'application/json'
+                }
+            };
+
+            context('when spec does not define content-type', function ()  {
 
                 var specReq = {
                     headers: [
@@ -20,15 +23,21 @@
                     ]
                 };
 
-                assert.equal(content.areContentTypesSame(httpReq, specReq), true);
+                it('should return true', function () {
+                    assert.equal(content.areContentTypesSame(httpReq, specReq), true);
+                });
+
+                it('should log to console that content type is matched', function () {
+                    var hook = stdoutHook.setup(function (string) {
+                        assert.equal(loadash.includes(string, 'NOT_MATCHED'), false);
+                    });
+
+                    content.areContentTypesSame(httpReq, specReq);
+                    hook();
+                });
             });
 
-            it('should be the same', function () {
-                var httpReq = {
-                    'headers': {
-                        'content-type': 'application/json'
-                    }
-                };
+            context('when headers correspond to spec', function ()  {
 
                 var specReq = {
                     headers: [
@@ -36,23 +45,40 @@
                     ]
                 };
 
-                assert.equal(content.areContentTypesSame(httpReq, specReq), true);
+                it('should returns true', function () {
+                    assert.equal(content.areContentTypesSame(httpReq, specReq), true);
+                });
+
+                it('should log to console that content type is matched', function () {
+                    var hook = stdoutHook.setup(function (string) {
+                        assert.equal(loadash.includes(string, 'NOT_MATCHED'), false);
+                    });
+
+                    content.areContentTypesSame(httpReq, specReq);
+                    hook();
+                });
             });
 
-            it('should not be the same', function () {
-                var httpReq = {
-                    'headers': {
-                        'content-type': 'application/xml'
-                    }
-                };
+            context('when headers do not correspond to spec', function ()  {
 
                 var specReq = {
                     headers: [
-                        {name: 'Content-Type', value: 'application/json'}
-                    ]
+                        {name: 'Content-Type', value: 'application/xml'}
+                    ],
                 };
 
-                assert.equal(content.areContentTypesSame(httpReq, specReq), false);
+                it('should returns false ', function () {
+                    assert.equal(content.areContentTypesSame(httpReq, specReq), false);
+                });
+
+                it('should log to console that content type is not matched', function () {
+                    var hook = stdoutHook.setup(function (string) {
+                        assert.equal(loadash.includes(string, 'NOT_MATCHED'), true);
+                    });
+
+                    content.areContentTypesSame(httpReq, specReq);
+                    hook();
+                });
             });
         });
 
@@ -114,81 +140,178 @@
             });
         });
 
-
         describe('matchesBody', function () {
-            it('should match body when there are no spec request', function () {
-                var httpReq = {
-                    body: ''
-                };
 
-                var specReq = null;
+            var httpReq = {
+                body: '{"text": "Hyperspeed jet"}',
+            };
 
-                assert.equal(content.matchesBody(httpReq, specReq), true);
-            });
+            context('when spec does not define', function ()  {
 
-            describe('content type is json', function () {
-                var httpReq = {
-                    'headers': {
-                        'content-type': 'application/json'
-                    }
-                };
-
-                it('should match body', function () {
-                    httpReq.body = '{"text": "Hyperspeed jet"}';
-
-                    var specReq = {
-                        body: '{\n    "text": "Hyperspeed jet"\n}\n'
-                    };
+                it('should return true', function () {
+                    var specReq = null;
 
                     assert.equal(content.matchesBody(httpReq, specReq), true);
                 });
 
-                it('should not match body', function () {
-                    httpReq.body = '{"text": "Hyperspeed jet!!"}';
+                it('should log to console that body matched', function () {
+                    httpReq.headers = {
+                        'content-type': 'application/json',
+                    };
 
                     var specReq = {
                         body: '{\n    "text": "Hyperspeed jet"\n}\n'
                     };
 
-                    assert.equal(content.matchesBody(httpReq, specReq), false);
+                    var hook = stdoutHook.setup(function (string) {
+                        assert.equal(loadash.includes(string, 'NOT_MATCHED'), false);
+                    });
+
+                    content.matchesBody(httpReq, specReq);
+
+                    hook();
                 });
             });
 
-            describe('content type is not json', function () {
-                var httpReq = {
-                    'headers': {
-                        'content-type': 'multipart'
-                    }
-                };
+            context('when body correspond to spec', function ()  {
 
-                it('should match body', function () {
-                    httpReq.body = '{"text": "Hyperspeed jet"}';
+                context('when content type is json', function ()  {
 
-                    var specReq = {
-                        body: '{"text": "Hyperspeed jet"}'
-                    };
+                    before(function ()  {
+                        httpReq.headers = {
+                            'content-type': 'application/json',
+                        };
+                    });
 
-                    assert.equal(content.matchesBody(httpReq, specReq), true);
+                    it('should returns true', function () {
+                        var specReq = {
+                            body: '{\n    "text": "Hyperspeed jet"\n}\n'
+                        };
+                        assert.equal(content.matchesBody(httpReq, specReq), true);
+                    });
                 });
 
-                it('should not match body', function () {
-                    httpReq.body = '{"text": "Hyperspeed jet!!"}';
+                context('when content type is not json', function ()  {
+
+                    before(function () {
+                        httpReq.headers = {
+                            'content-type': 'multipart'
+                        };
+                    });
+
+                    it('should returns true', function () {
+                        var specReq = {
+                            body: '{"text": "Hyperspeed jet"}'
+                        };
+                        assert.equal(content.matchesBody(httpReq, specReq), true);
+                    });
+                });
+
+                it('should log to console that body matched', function () {
+                    httpReq.headers = {
+                        'content-type': 'application/json',
+                    };
 
                     var specReq = {
                         body: '{\n    "text": "Hyperspeed jet"\n}\n'
                     };
 
-                    assert.equal(content.matchesBody(httpReq, specReq), false);
+                    var hook = stdoutHook.setup(function (string) {
+                        assert.equal(loadash.includes(string, 'NOT_MATCHED'), false);
+                    });
+
+                    content.matchesBody(httpReq, specReq);
+
+                    hook();
+                });
+            });
+
+            context('when body do not correspond to spec', function ()  {
+
+                context('when content type is json', function ()  {
+
+                    before(function () {
+                        httpReq.headers = {
+                            'content-type': 'application/json',
+                        };
+                    });
+
+                    it('should returns false', function () {
+                        var specReq = {
+                            body: '{"text": "Hyperspeed jet!!!!!"}'
+                        };
+
+                        assert.equal(content.matchesBody(httpReq, specReq), false);
+                    });
+                });
+
+                context('when content type is not json', function ()  {
+
+                    before(function () {
+                        httpReq.headers = {
+                            'content-type': 'multipart',
+                        };
+                    });
+
+                    it('should returns false', function () {
+                        var specReq = {
+                            body: '{\n    "text": "Hyperspeed jet"\n}\n'
+                        };
+
+                        assert.equal(content.matchesBody(httpReq, specReq), false);
+                    });
+                });
+
+                it('should log to console that body is not matched', function () {
+                    httpReq.headers = {
+                        'content-type': 'application/json',
+                    };
+
+                    var specReq = {
+                        body: '{"text": "Hyperspeed jet!!!!"\n}\n'
+                    };
+
+                    var hook = stdoutHook.setup(function (string) {
+                        assert.equal(loadash.includes(string, 'NOT_MATCHED'), true);
+                    });
+
+                    content.matchesBody(httpReq, specReq);
+
+                    hook();
                 });
             });
         });
 
         describe('matchesSchema', function () {
-            it('should match when spec request is null', function () {
-                assert.equal(content.matchesSchema({}, null), true);
+
+            var httpReq = {
+                'headers': {
+                    'content-type': 'application/json'
+                },
+                body: '{"first": "text", "second": "text2"}'
+            };
+
+            context('when spec does not define', function () {
+
+                var specReq = null;
+
+                it('should returns true', function () {
+                    assert.equal(content.matchesSchema(httpReq, specReq), true);
+                });
+
+                it('should log to console that schema is matched', function () {
+                    var hook = stdoutHook.setup(function (string) {
+                        assert.equal(loadash.includes(string, 'NOT_MATCHED'), false);
+                    });
+
+                    content.matchesSchema(httpReq, specReq);
+
+                    hook();
+                });
             });
 
-            describe('schema exist', function () {
+            context('when schema correspond to spec', function () {
+
                 var specReq = {
                     schema: {
                         type: 'object',
@@ -200,40 +323,111 @@
                     }
                 };
 
-                it('should match with schema', function () {
-                    var httpReq = {
-                        'headers': {
-                            'content-type': 'application/json'
-                        },
-                        body: '{"first": "text", "second": "text2"}'
-                    };
-
+                it('should returns true', function () {
                     assert.equal(content.matchesSchema(httpReq, specReq), true);
                 });
 
-                it('should not match with schema', function () {
-                    var httpReq = {
-                        'headers': {
-                            'content-type': 'application/json'
-                        },
-                        body: '{"first": "text", "third": "text2"}'
-                    };
+                it('should log to console that schema is matched', function () {
+                    var hook = stdoutHook.setup(function (string) {
+                        assert.equal(loadash.includes(string, 'NOT_MATCHED'), false);
+                    });
 
+                    content.matchesSchema(httpReq, specReq);
+
+                    hook();
+                });
+            });
+
+            context('when schema do not correspond to spec', function () {
+
+                var specReq = {
+                    schema: {
+                        type: 'object',
+                        required: ['first', 'second'],
+                        properties: {
+                            first: {type: 'number'},
+                            second: {type: 'string'}
+                        }
+                    }
+                };
+
+                it('should returns fals', function () {
                     assert.equal(content.matchesSchema(httpReq, specReq), false);
+                });
+
+                it('should log to console that schema is not matched', function () {
+                    var hook = stdoutHook.setup(function (string) {
+                        assert.equal(loadash.includes(string, 'NOT_MATCHED'), true);
+                    });
+
+                    content.matchesSchema(httpReq, specReq);
+
+                    hook();
                 });
             });
         });
 
         describe('matchesHeader', function () {
-            it('should match when spec request is null', function () {
-                assert.equal(content.matchesHeader({}, null), true);
+
+            var httpReq = {
+                'headers': {
+                    'random-value': 'random',
+                    'content-type': 'application/json',
+                    'hello': 'World',
+                    'custom-header': 'test'
+                }
+            };
+
+            context('when spec does not exist', function () {
+
+                var specReq = null;
+
+                it('should return true', function () {
+                    assert.equal(content.matchesHeader(httpReq, specReq), true);
+                });
+
+                it('should log to console that schema is matched', function () {
+                    var numberOfErrors = 0;
+                    var hook = stdoutHook.setup(function (string) {
+                        if (loadash.includes(string, 'NOT_MATCHED')) {
+                            numberOfErrors += 1;
+                        }
+                    });
+
+                    content.matchesHeader(httpReq, specReq);
+
+                    hook();
+
+                    assert.equal(numberOfErrors, 0);
+                });
             });
 
-            it('should match when there are no headers', function () {
-                assert.equal(content.matchesHeader({}, {headers: ''}), true);
+            context('when spec is empty', function () {
+
+                var specReq = { headers: '' };
+
+                it('should return true', function () {
+                    assert.equal(content.matchesHeader(httpReq, specReq), true);
+                });
+
+                it('should log to console that schema is matched', function () {
+                    var numberOfErrors = 0;
+                    var hook = stdoutHook.setup(function (string) {
+                        if (loadash.includes(string, 'NOT_MATCHED')) {
+                            numberOfErrors += 1;
+                        }
+                    });
+
+                    content.matchesHeader(httpReq, specReq);
+
+                    hook();
+
+                    assert.equal(numberOfErrors, 0);
+                });
             });
 
-            describe('header exist', function () {
+            context('when headers correspond to spec', function () {
+
                 var specReq = {
                     headers: [
                         {name: 'Content-Type', value: 'application/json'},
@@ -242,29 +436,54 @@
                     ]
                 };
 
-                it('should match header', function () {
-                    var httpReq = {
-                        'headers': {
-                            'random-value': 'random',
-                            'content-type': 'application/json',
-                            'hello': 'World',
-                            'custom-header': 'test'
-                        }
-                    };
-
+                it('should return true', function () {
                     assert.equal(content.matchesHeader(httpReq, specReq), true);
                 });
 
-                it('should not match header', function () {
-                    var httpReq = {
-                        'headers': {
-                            'random-value': 'random',
-                            'content-type': 'application/json',
-                            'Hello': 'World'
+                it('should log to console that schema is matched', function () {
+                    var numberOfErrors = 0;
+                    var hook = stdoutHook.setup(function (string) {
+                        if (loadash.includes(string, 'NOT_MATCHED')) {
+                            numberOfErrors += 1;
                         }
-                    };
+                    });
 
+                    content.matchesHeader(httpReq, specReq);
+
+                    hook();
+
+                    assert.equal(numberOfErrors, 0);
+                });
+            });
+
+            context('when headers do not correspond to spec', function () {
+
+                var specReq = {
+                    headers: [
+                        {name: 'Content-Type', value: 'application/json'},
+                        {name: 'Custom-header', value: 'test'},
+                        {name: 'Hello', value: 'World'},
+                        {name: 'some-another-header', value: 'some value'},
+                    ]
+                };
+
+                it('should return false', function () {
                     assert.equal(content.matchesHeader(httpReq, specReq), false);
+                });
+
+                it('should log to console that schema does not match', function () {
+                    var numberOfErrors = 0;
+                    var hook = stdoutHook.setup(function (string) {
+                        if (loadash.includes(string, 'NOT_MATCHED')) {
+                            numberOfErrors += 1;
+                        }
+                    });
+
+                    content.matchesHeader(httpReq, specReq);
+
+                    hook();
+
+                    assert.equal(numberOfErrors, 1);
                 });
             });
         });


### PR DESCRIPTION
Here is #139 PR, with resolved conflicts and added tests for logging diagnostic info.
Also I've refactored tests little bit, made them more readable by adding more context info.

This changes handle (and provide ability to debug) such kind of errors:

when request's path does not matched any documented endpoints
when request's headers does not matched headers schema for this endpoint
when request's body does not matched body schema (corresponding to request's content-type) for this endpoint