### PR TITLE
Fix function drakov.stop dosen’t work

### DIFF
--- a/lib/drakov.js
+++ b/lib/drakov.js
@@ -56,7 +56,7 @@ exports.stop = function(cb) {
         }
     };
     try {
-        server.close(function() {
+        server.forceShutdown(function() {
             console.log('   DRAKOV STOPPED   '.red.bold.inverse);
             runCb();
         });

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,11 +1,15 @@
 var fs = require('fs');
+var http = require('http');
 var https = require('https');
+var httpShutdown = require('http-shutdown');
 
 var version = require('../package.json').version;
 
 exports.isSSL = false;
 
 exports.startServer = function (argv, app, cb) {
+
+    var server = null;
 
     var startCb = function() {
         console.log(('   Drakov ' + version + '     ').bold.inverse, 'Listening on port ' + argv.serverPort.toString().bold.red);
@@ -22,7 +26,6 @@ exports.startServer = function (argv, app, cb) {
         }
     };
 
-    var server = null;
     if (argv.sslKeyFile && argv.sslCrtFile) {
         exports.isSSL = true;
         var sslOptions = {
@@ -32,8 +35,12 @@ exports.startServer = function (argv, app, cb) {
         };
         server = https.createServer(sslOptions, app);
     } else {
-        server = app;
+        //server = app;
+        server = http.createServer(app);
     }
+    
+    server = httpShutdown(server);
+
 
     if (argv.public) {
         return server.listen(argv.serverPort, startCb);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "drafter": "^1.2.0",
     "express": "^4.14.1",
     "glob": "^7.1.1",
+    "http-shutdown": "^1.2.0",
     "jade": "^1.11.0",
     "lodash": "^4.17.4",
     "path-to-regexp": "^1.7.0",


### PR DESCRIPTION
When I call the function `.stop()`, it only stops accepting new connections, it doesn't terminate existing connections. 
Because if `Connection: keep-alive` was requested by the client. It's an HTTP/1.1 feature to reduce the overhead of creating and tearing down a connection for each HTTP request.