### PR TITLE
Set --ignoreHeader command line argument type as 'array'

### DIFF
--- a/lib/arguments/arguments.js
+++ b/lib/arguments/arguments.js
@@ -59,7 +59,7 @@ module.exports = {
         description: 'Enables DEBUG mode. Mismatch requests will be dumped'
     },
     ignoreHeader: {
-        description: 'Ignore the HTTP header in API blueprints'
+        description: 'Ignore the HTTP header in API blueprints',
+        type: 'array'
     }
-
 };


### PR DESCRIPTION
Specifying `--ignoreHeader Authorization` once in the command line fails as the internal code is expecting an array. (https://github.com/Aconex/drakov/blob/master/lib/content.js#L114)