### PR TITLE
Node 8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "5"
   - "6"
   - "7"
+  - "8"
 notifications:
   email:
     - yakov@therocketsurgeon.com

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ It can be found at [https://groups.google.com/forum/?hl=en#!forum/drakov-api-ser
 
 Since version 1.0.2, a version of the Drafter package is being used, which attempts to install the version with C bindings (faster), but falls back if compilation of this package fails to Drafter.js.
 
-Currently this package doesn't install on Node.js version 7+. All versions below and including Node.js 6.x will work fine.
-
 
 ## MSON Support via Attribute elements
 


### PR DESCRIPTION
The README currently states that this package does not work on Node.js 7+, but using Node.js 8 on Linux, I'm not noticing any issue, and the test suite passes. The Travis CI build also passes with up to Node.js 8.

Let's trade this outdated statement for this Travis build.