### PR TITLE
Add returning reason if the schema was not matched with the request

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -102,7 +102,7 @@ exports.matchesSchema = function(httpReq, specReq) {
     var contentType = getMediaTypeFromHttpReq(httpReq);
     var reqBody = getBodyContent(httpReq, isJson(contentType));
     var result =  specSchema.matchWithSchema(reqBody, specReq.schema);
-    logger.log('[MATCHING]'.yellow,'by request body schema', logger.stringfy(result));
+    logger.log('[MATCHING]'.yellow,'by request body schema', logger.stringfy(result.valid));
     return result;
 };
 

--- a/lib/debugRequest.js
+++ b/lib/debugRequest.js
@@ -15,7 +15,6 @@ exports.notFoundHandler = function(argv) {
             }
             return req.body;
         }
-
         var debugObj = {
             originalUrl: req.originalUrl,
             body: getBody(req),

--- a/lib/handler-filter.js
+++ b/lib/handler-filter.js
@@ -15,7 +15,7 @@ var filterRequestBody = function (req) {
 
 var filterSchema = function (req) {
     return function (handler) {
-        return content.matchesSchema(req, handler.request);
+        return content.matchesSchema(req, handler.request).valid;
     };
 };
 
@@ -40,11 +40,37 @@ exports.filterHandlers = function (req, handlers, ignoreHeaders) {
         if (matchRequestBodyHandlers.length > 0) {
             return matchRequestBodyHandlers[0];
         }
+        var filteredSchema = filterSchema(req);
+        
 
-        var matchSchemaHandlers = filteredHandlers.filter(filterSchema(req));
+        var err;
+        filteredHandlers.map(function handerError(handler) {
+          var res = content.matchesSchema(req, handler.request);
+          if (res.valid === false) {
+            handler.response.name = '404';
+            handler.response.body = {
+              method: req.method,
+              headers: req.headers, 
+              originalUrl: req.originalUrl,
+              error: {
+                params: res.errors[0].params,
+                message: res.errors[0].message,
+                dataPath: res.errors[0].dataPath,
+                schemaPath: res.errors[0].schemaPath
+              }
+            };
+            err = handler;
+          }
+        });
+        
+        var matchSchemaHandlers = filteredHandlers.filter(filteredSchema);
 
         if (matchSchemaHandlers.length > 0) {
             return matchSchemaHandlers[0];
+        }
+
+        if (err !== null) {
+          return err;
         }
     }
 

--- a/lib/spec-schema.js
+++ b/lib/spec-schema.js
@@ -16,8 +16,8 @@ exports.hasSchema =  function (spec){
     return !!spec.schema;
 };
 
-exports.matchWithSchema = function (json, schema){
-    return tv4.validate(json, schema);
+exports.matchWithSchema = function (json, schema) {
+    return tv4.validateMultiple(json, schema);
 };
 
 exports.validateAndParseSchema = function (spec){
@@ -27,5 +27,4 @@ exports.validateAndParseSchema = function (spec){
     }
     return spec;
 };
-
 

--- a/test/api/form-urlencoded-test.js
+++ b/test/api/form-urlencoded-test.js
@@ -31,7 +31,7 @@ describe('UrlEncoded Requests', function() {
                     .send('random_number=555&static=magic')
 
                     .expect(404)
-                    .expect('Content-type', 'text/html; charset=utf-8')
+                    .expect('Content-type', 'application/json;charset=UTF-8')
                     .end(helper.endCb(done));
             });
         });

--- a/test/unit/content-test.js
+++ b/test/unit/content-test.js
@@ -257,7 +257,7 @@
                 };
 
                 it('should returns true', function () {
-                    assert.equal(content.matchesSchema(httpReq, specReq), true);
+                    assert.equal(content.matchesSchema(httpReq, specReq).valid, true);
                 });
 
                 it('should log to console that schema is matched', function () {
@@ -285,7 +285,7 @@
                 };
 
                 it('should returns fals', function () {
-                    assert.equal(content.matchesSchema(httpReq, specReq), false);
+                    assert.equal(content.matchesSchema(httpReq, specReq).valid, false);
                 });
 
                 it('should log to console that schema is not matched', function () {

--- a/test/unit/spec-schema-test.js
+++ b/test/unit/spec-schema-test.js
@@ -24,11 +24,11 @@ describe('Spec Schema', function() {
 
     describe ('matchWithSchema', function() {
         it('Should return true when json is validated against schema', function () {
-            assert.equal(specSchema.matchWithSchema({id: 1}, schema), true);
+            assert.equal(specSchema.matchWithSchema({id: 1}, schema).valid, true);
         });
 
         it('Should return false when json is not validated against schema', function () {
-            assert.equal(specSchema.matchWithSchema({idea: 1}, schema), false);
+            assert.equal(specSchema.matchWithSchema({idea: 1}, schema).valid, false);
         });
     });
 


### PR DESCRIPTION
In my recent experience with the Drakov mock-server, I have some APIs with many parameters and when Frontend teams send the requests to the mock-server, it was hard to them to find what's the source of the problem in a direct way. I have added returning reason in the 404 response.