### PR TITLE
(ignoreHeaders) allow ignore single header. fixes #192

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -111,9 +111,10 @@ exports.matchesHeader = function(httpReq, specReq, ignoreHeaders) {
         return true;
     }
 
-    ignoreHeaders = (typeof(ignoreHeaders)=='object' && ignoreHeaders.map(function (header) {
+    if (typeof(ignoreHeaders)=='string') { ignoreHeaders = [ignoreHeaders]; }
+    ignoreHeaders = (ignoreHeaders && ignoreHeaders.map(function (header) {
       return header.toLowerCase();
-    })) || [(ignoreHeaders||"").toString().toLowerCase()];
+    })) || [];
 
     function shouldIgnoreHeader(headerName){
         return ignoreHeaders.indexOf(headerName.toLowerCase()) > -1;

--- a/lib/content.js
+++ b/lib/content.js
@@ -111,7 +111,7 @@ exports.matchesHeader = function(httpReq, specReq, ignoreHeaders) {
         return true;
     }
 
-    if (typeof(ignoreHeaders)=='string') { ignoreHeaders = [ignoreHeaders]; }
+    if (typeof(ignoreHeaders)==='string') { ignoreHeaders = [ignoreHeaders]; }
     ignoreHeaders = (ignoreHeaders && ignoreHeaders.map(function (header) {
       return header.toLowerCase();
     })) || [];

--- a/lib/content.js
+++ b/lib/content.js
@@ -111,9 +111,9 @@ exports.matchesHeader = function(httpReq, specReq, ignoreHeaders) {
         return true;
     }
 
-    ignoreHeaders = (ignoreHeaders && ignoreHeaders.map(function (header) {
+    ignoreHeaders = (typeof(ignoreHeaders)=='object' && ignoreHeaders.map(function (header) {
       return header.toLowerCase();
-    })) || [];
+    })) || [(ignoreHeaders||"").toString().toLowerCase()];
 
     function shouldIgnoreHeader(headerName){
         return ignoreHeaders.indexOf(headerName.toLowerCase()) > -1;


### PR DESCRIPTION
#192 
- arguments are read in as array only if there is multiple of those in the command
- if it is a string, place the string in an array instead